### PR TITLE
Certifier: Generate one Proof .agda file per certified pass

### DIFF
--- a/plutus-metatheory/src/Certifier.hs
+++ b/plutus-metatheory/src/Certifier.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wall #-}
 
@@ -15,10 +17,12 @@ import Control.Monad.Except (ExceptT (..), runExceptT, throwError)
 import Control.Monad.IO.Class (liftIO)
 import Data.FileEmbed (embedStringFile)
 import Data.Foldable
+import Data.List (intercalate)
 import Data.List.Extra (replace)
-import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty (NonEmpty (..), cons)
 import Data.List.NonEmpty qualified as NE
 import Data.List.NonEmptySep as NES
+import Data.String
 import Data.Text qualified as Text
 import Data.Text.IO qualified as T
 import System.Directory (createDirectoryIfMissing)
@@ -135,27 +139,107 @@ mkCertificate certName rawTrace =
   "Data" :| ["List", "NonEmpty"] -}
 type ModuleName = NonEmpty String
 
-moduleIdent :: ModuleName -> String
-moduleIdent = fold . NE.intersperse "."
+-- | Convert module name to an Agda identifier
+toIdent :: ModuleName -> String
+toIdent = fold . NE.intersperse "."
 
-moduleFileName :: ModuleName -> FilePath
-moduleFileName m = foldr (</>) "" m ++ ".agda"
+-- | Convert module name to .agda filepath relative to the source directory
+toFilePath :: ModuleName -> FilePath
+toFilePath m = foldr (</>) "" m ++ ".agda"
 
 -- | Drops the last component of the module to obtain its directory
 moduleDir :: ModuleName -> String
 moduleDir m = foldr (</>) "" (NE.init m)
 
-{-| Module name in agda, for a given equivalence class. Each list element is a module segment that is to be
-separated by "." (agda identifier) or by "/" (files) -}
-mkAstModuleName :: Int -> ModuleName
-mkAstModuleName n =
-  ("Pass" <> printf "%03d" n) :| ["AST"]
+enclose :: String -> String -> String -> String
+enclose l r x = l ++ x ++ r
 
-mkAgdaAstFile :: Int -> UTerm -> Maybe Hints -> (ModuleName, String)
+data ImportHow = Open | Closed
+
+type Import = (ImportHow, ModuleName, [String])
+
+renderImport :: Import -> String
+renderImport (how, name, idents) =
+  renderHow ++ "import " ++ toIdent name ++ renderUsing
+  where
+    renderHow = case how of
+      Open -> "open "
+      Closed -> ""
+    renderUsing
+      | null idents = ""
+      | otherwise = " using (" ++ intercalate ", " idents ++ ")"
+
+{-| Module name in agda, for a given ast number and module name. Each list element is a module segment that is to be
+separated by "." (agda identifier) or by "/" (files) -}
+passModName :: String -> Int -> ModuleName
+passModName name n =
+  ("Pass" <> printf "%03d" n) :| [name]
+
+astModName :: Int -> ModuleName
+astModName n = passModName "AST" n
+
+proofModName :: Int -> ModuleName
+proofModName n = passModName "Proof" n
+
+proofFile :: Int -> UTerm -> Maybe (OptStage, Hints) -> (ModuleName, String)
+proofFile n _ Nothing = (proofModName n, [])
+proofFile n _ (Just (pass, _)) =
+  ( modName
+  , unlines $
+      [ "module " <> toIdent modName <> " where"
+      , ""
+      ]
+        ++ map renderImport imports
+        ++ [ ""
+           , "related : " ++ proofSig
+           , "related = " ++ proofExpr
+           ]
+  )
+  where
+    modName = proofModName n
+
+    preMod = astModName n
+    postMod = astModName (n + 1)
+
+    preTerm = toIdent preMod ++ ".ast"
+    postTerm = toIdent postMod ++ ".ast"
+    hints = toIdent preMod ++ ".hints"
+
+    proofSig :: String
+    proofSig =
+      unwords
+        ["RelationOf", renderAgdaUnparse pass, preTerm, postTerm]
+
+    proofExpr :: String
+    proofExpr =
+      unwords
+        [ "to-witness-T"
+        , enclose "(" ")" . unwords $
+            [ "certifyPass"
+            , renderAgdaUnparse pass
+            , hints
+            , preTerm
+            , postTerm
+            ]
+        , "tt"
+        ]
+
+    imports :: [(ImportHow, ModuleName, [String])]
+    imports =
+      [ (Closed, preMod, [])
+      , (Closed, postMod, [])
+      , (Open, "Data" :| ["Unit"], ["tt"])
+      , (Open, "VerifiedCompilation" :| [], [])
+      , (Open, "VerifiedCompilation" :| "Trace" : [], [])
+      , (Open, "VerifiedCompilation" :| "Certificate" : [], [])
+      , (Open, "Utils" :| [], [])
+      ]
+
+mkAgdaAstFile :: Int -> UTerm -> Maybe (OptStage, Hints) -> (ModuleName, String)
 mkAgdaAstFile n pre mHints =
   ( modName
   , unlines $
-      [ "module " <> moduleIdent modName <> " where"
+      [ "module " <> toIdent modName <> " where"
       , ""
       , "open import Data.Unit"
       , "open import Data.Nat"
@@ -179,7 +263,7 @@ mkAgdaAstFile n pre mHints =
       , "ast = to-witness-T (checkScope raw) tt"
       ]
         ++ case mHints of
-          Just hints ->
+          Just (_, hints) ->
             [ ""
             , "hints : Hints"
             , "hints = " <> renderAgdaUnparse hints
@@ -187,16 +271,13 @@ mkAgdaAstFile n pre mHints =
           Nothing -> []
   )
   where
-    modName = mkAstModuleName n
-
-mkAgdaImport :: Bool -> ModuleName -> String
-mkAgdaImport open moduleName =
-  openModifier open ("import " <> moduleIdent moduleName)
-  where
-    openModifier True str = "open " <> str
-    openModifier False str = str
+    modName = astModName n
 
 newtype AgdaVar = AgdaVar String
+  deriving (IsString)
+
+qualify :: ModuleName -> AgdaVar -> AgdaVar
+qualify modName (AgdaVar x) = AgdaVar (toIdent modName ++ "." ++ x)
 
 instance AgdaUnparse AgdaVar where
   agdaUnparse (AgdaVar var) = pretty var
@@ -213,7 +294,7 @@ mkCertificateFile Certificate {certName, certTrace} =
     , "open import Data.Unit"
     , ""
     ]
-      ++ map (mkAgdaImport False) astImports
+      ++ map renderImport (astImports ++ proofImports)
       ++ [ ""
          , "trace : Trace (0 ⊢)"
          , "trace ="
@@ -221,30 +302,41 @@ mkCertificateFile Certificate {certName, certTrace} =
       ++ map ("  " ++) (printTrace traceExpr)
       ++ [ ""
          , "certificate : Certificate trace"
-         , "certificate = cert trace (certify trace) tt"
-         , ""
+         , "certificate = "
+         , renderProof proofExpr
          ]
   where
-    astImports :: [ModuleName]
-    astImports = map mkAstModuleName [0 .. length certTrace - 1]
+    astImports :: [Import]
+    astImports = map (\n -> (Closed, astModName n, [])) [0 .. length certTrace - 1]
 
-    -- replace hints and asts by agda variables that point to the right module
+    proofImports :: [Import]
+    proofImports = map (\n -> (Closed, proofModName n, [])) [0 .. length certTrace - 2]
+
+    -- Replace hints and ASTs in the trace by agda variables that point to the right definition
     traceExpr :: NonEmptySep (OptStage, AgdaVar) AgdaVar
     traceExpr = go 0 certTrace
       where
-        go n (Singleton _) = Singleton (moduleVar n "ast")
+        go n (Singleton _) = Singleton (qualify (astModName n) (AgdaVar "ast"))
         go n (Cons _ (stage, _) xs) =
           Cons
-            (moduleVar n "ast")
-            (stage, moduleVar n "hints")
+            (qualify (astModName n) "ast")
+            (stage, qualify (astModName n) "hints")
             (go (n + 1) xs)
 
-    moduleVar :: Int -> String -> AgdaVar
-    moduleVar n x =
-      AgdaVar $
-        moduleIdent (mkAstModuleName n)
-          <> "."
-          <> x
+    -- Non-empty list of variables that point to the proofs per pass
+    proofExpr :: NonEmpty AgdaVar
+    proofExpr = go 0 certTrace
+      where
+        go _ (Singleton _) = AgdaVar "tt" :| []
+        go n (Cons _ _ xs) = cons (qualify (proofModName n) (AgdaVar "related")) (go (n + 1) xs)
+
+-- Print the imported proofs as a big product
+renderProof :: NonEmpty AgdaVar -> String
+renderProof (AgdaVar x :| xs) =
+  unlines $
+    [("  ( " ++ x)]
+      ++ map (\(AgdaVar p) -> "  , " ++ p) xs
+      ++ [("  )")]
 
 -- Ad-hoc pretty printing so it can be printed over multiple lines
 printTrace :: NonEmptySep (OptStage, AgdaVar) AgdaVar -> [String]
@@ -258,8 +350,20 @@ printTrace (Cons x (stage, y) xs) =
 data AgdaCertificateProject = AgdaCertificateProject
   { mainModule :: (FilePath, String)
   , astModules :: [(ModuleName, String)]
+  , proofModNames :: [(ModuleName, String)]
   , agdalib :: (FilePath, String)
   }
+
+{-| For each term in the trace, create module contents using the given
+function, which is also passed the index in the trace. -}
+traceToFiles
+  :: (Int -> UTerm -> Maybe (OptStage, Hints) -> (ModuleName, String))
+  -> Trace UTerm
+  -> [(ModuleName, String)]
+traceToFiles f t = go 0 t
+  where
+    go n (Singleton x) = [f n x Nothing]
+    go n (Cons x (o, h) xs) = f n x (Just (o, h)) : go (n + 1) xs
 
 mkAgdaLib :: String -> (FilePath, String)
 mkAgdaLib name =
@@ -279,17 +383,15 @@ mkAgdaCertificateProject
 mkAgdaCertificateProject cert =
   let name = certName cert
       mainModule = mkCertificateFile cert
-      astModules = astModuleFiles 0 (certTrace cert)
+      astModules = traceToFiles mkAgdaAstFile (certTrace cert)
+      proofModNames = traceToFiles proofFile (certTrace cert)
       agdalib = mkAgdaLib name
    in AgdaCertificateProject
         { mainModule = (certName cert <> ".agda", mainModule)
         , astModules
+        , proofModNames
         , agdalib
         }
-  where
-    astModuleFiles :: Int -> Trace UTerm -> [(ModuleName, String)]
-    astModuleFiles n (Singleton x) = [mkAgdaAstFile n x Nothing]
-    astModuleFiles n (Cons x (_, h) xs) = mkAgdaAstFile n x (Just h) : astModuleFiles (n + 1) xs
 
 writeCertificateProject
   :: CertDir
@@ -300,6 +402,7 @@ writeCertificateProject
   AgdaCertificateProject
     { mainModule
     , astModules
+    , proofModNames
     , agdalib
     } =
     liftIO $ do
@@ -308,14 +411,13 @@ writeCertificateProject
           certName = takeBaseName mainModulePath
       createDirectoryIfMissing True certDir
       createDirectoryIfMissing True (certDir </> "src")
-      for_ astModules $ \(modName, _) -> do
+
+      -- directory per AST in trace
+      for_ (astModules ++ proofModNames) $ \(modName, contents) -> do
         createDirectoryIfMissing True (certDir </> "src" </> moduleDir modName)
+        writeFile (certDir </> "src" </> toFilePath modName) contents
+
       writeFile (certDir </> "src" </> mainModulePath) mainModuleContents
       writeFile (certDir </> agdalibPath) agdalibContents
       let readmeTemplate = $(embedStringFile "file-embed/certificate-README.md")
       writeFile (certDir </> "README.md") (replace "{{NAME}}" certName readmeTemplate)
-      traverse_
-        ( \(modName, contents) ->
-            writeFile (certDir </> "src" </> moduleFileName modName) contents
-        )
-        astModules

--- a/plutus-metatheory/src/Certifier.hs
+++ b/plutus-metatheory/src/Certifier.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wall #-}
 
@@ -22,7 +21,6 @@ import Data.List.Extra (replace)
 import Data.List.NonEmpty (NonEmpty (..), cons)
 import Data.List.NonEmpty qualified as NE
 import Data.List.NonEmptySep as NES
-import Data.String
 import Data.Text qualified as Text
 import Data.Text.IO qualified as T
 import System.Directory (createDirectoryIfMissing)
@@ -274,7 +272,6 @@ mkAgdaAstFile n pre mHints =
     modName = astModName n
 
 newtype AgdaVar = AgdaVar String
-  deriving (IsString)
 
 qualify :: ModuleName -> AgdaVar -> AgdaVar
 qualify modName (AgdaVar x) = AgdaVar (toIdent modName ++ "." ++ x)
@@ -319,8 +316,8 @@ mkCertificateFile Certificate {certName, certTrace} =
         go n (Singleton _) = Singleton (qualify (astModName n) (AgdaVar "ast"))
         go n (Cons _ (stage, _) xs) =
           Cons
-            (qualify (astModName n) "ast")
-            (stage, qualify (astModName n) "hints")
+            (qualify (astModName n) (AgdaVar "ast"))
+            (stage, qualify (astModName n) (AgdaVar "hints"))
             (go (n + 1) xs)
 
     -- Non-empty list of variables that point to the proofs per pass

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation.hs
@@ -86,19 +86,19 @@ d_certifyPass_26 v0 v1
         -> case coe v2 of
              MAlonzo.Code.VerifiedCompilation.Trace.C_floatDelayT_14
                -> coe
-                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_192
+                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_204
                     (coe
                        MAlonzo.Code.VerifiedCompilation.UFloatDelay.d_isFloatDelay'63'_102
                        (coe (0 :: Integer)))
              MAlonzo.Code.VerifiedCompilation.Trace.C_forceDelayT_16
                -> coe
-                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_192
+                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_204
                     (coe
                        MAlonzo.Code.VerifiedCompilation.UForceDelay.d_isForceDelay'63'_178
                        (coe (0 :: Integer)))
              MAlonzo.Code.VerifiedCompilation.Trace.C_forceCaseDelayT_18
                -> coe
-                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_192
+                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_204
                     (coe
                        MAlonzo.Code.VerifiedCompilation.UForceCaseDelay.d_isForceCaseDelay'63'_94
                        (coe (0 :: Integer)))
@@ -106,7 +106,7 @@ d_certifyPass_26 v0 v1
                -> case coe v1 of
                     MAlonzo.Code.VerifiedCompilation.Trace.C_inline_82 v3
                       -> coe
-                           MAlonzo.Code.VerifiedCompilation.Certificate.du_checker_156
+                           MAlonzo.Code.VerifiedCompilation.Certificate.du_checker_168
                            (coe
                               MAlonzo.Code.VerifiedCompilation.UInline.d_top'45'check_718
                               (coe v3))
@@ -117,25 +117,25 @@ d_certifyPass_26 v0 v1
                     _ -> MAlonzo.RTE.mazUnreachableError
              MAlonzo.Code.VerifiedCompilation.Trace.C_cseT_22
                -> coe
-                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_192
+                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_204
                     (coe
                        MAlonzo.Code.VerifiedCompilation.UCSE.d_isUntypedCSE'63'_22
                        (coe (0 :: Integer)))
              MAlonzo.Code.VerifiedCompilation.Trace.C_applyToCaseT_24
                -> coe
-                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_192
+                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_204
                     (coe
                        MAlonzo.Code.VerifiedCompilation.UApplyToCase.d_a2c'63''7580''7580'_24
                        (coe (0 :: Integer)))
              MAlonzo.Code.VerifiedCompilation.Trace.C_caseReduceT_26
                -> coe
-                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_192
+                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_204
                     (coe
                        MAlonzo.Code.VerifiedCompilation.UCaseReduce.d_decide_526
                        (coe (0 :: Integer)))
              MAlonzo.Code.VerifiedCompilation.Trace.C_letFloatOutT_28
                -> coe
-                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_192
+                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_204
                     (coe
                        MAlonzo.Code.VerifiedCompilation.FloatOut.d_decide_312
                        (coe (0 :: Integer)))

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/Certificate.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/Certificate.hs
@@ -39,156 +39,179 @@ data T_CertResult_12
                   MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
                   MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
                AgdaAny AgdaAny
+-- VerifiedCompilation.Certificate.is-proof
+d_is'45'proof_36 ::
+  MAlonzo.Code.Agda.Primitive.T_Level_18 ->
+  () -> T_CertResult_12 -> Bool
+d_is'45'proof_36 ~v0 ~v1 v2 = du_is'45'proof_36 v2
+du_is'45'proof_36 :: T_CertResult_12 -> Bool
+du_is'45'proof_36 v0
+  = case coe v0 of
+      C_proof_18 v1 -> coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10
+      C_ce_26 v4 v5 v6 -> coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8
+      C_abort_32 v3 v4 v5 -> coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- VerifiedCompilation.Certificate.to-witness-T
+d_to'45'witness'45'T_42 ::
+  MAlonzo.Code.Agda.Primitive.T_Level_18 ->
+  () -> T_CertResult_12 -> AgdaAny -> AgdaAny
+d_to'45'witness'45'T_42 ~v0 ~v1 v2 ~v3
+  = du_to'45'witness'45'T_42 v2
+du_to'45'witness'45'T_42 :: T_CertResult_12 -> AgdaAny
+du_to'45'witness'45'T_42 v0
+  = case coe v0 of
+      C_proof_18 v1 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.Certificate.ProofOrCE
-d_ProofOrCE_38 a0 a1 = ()
-data T_ProofOrCE_38
-  = C_proof_44 AgdaAny |
-    C_ce_52 (MAlonzo.Code.Utils.T_Either_6
+d_ProofOrCE_50 a0 a1 = ()
+data T_ProofOrCE_50
+  = C_proof_56 AgdaAny |
+    C_ce_64 (MAlonzo.Code.Utils.T_Either_6
                MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
                MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
             AgdaAny AgdaAny
 -- VerifiedCompilation.Certificate.isProof?
-d_isProof'63'_56 ::
+d_isProof'63'_68 ::
   MAlonzo.Code.Agda.Primitive.T_Level_18 ->
-  () -> T_ProofOrCE_38 -> Bool
-d_isProof'63'_56 ~v0 ~v1 v2 = du_isProof'63'_56 v2
-du_isProof'63'_56 :: T_ProofOrCE_38 -> Bool
-du_isProof'63'_56 v0
+  () -> T_ProofOrCE_50 -> Bool
+d_isProof'63'_68 ~v0 ~v1 v2 = du_isProof'63'_68 v2
+du_isProof'63'_68 :: T_ProofOrCE_50 -> Bool
+du_isProof'63'_68 v0
   = case coe v0 of
-      C_proof_44 v1 -> coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10
-      C_ce_52 v4 v5 v6 -> coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8
+      C_proof_56 v1 -> coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10
+      C_ce_64 v4 v5 v6 -> coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8
       _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.Certificate.isCE?
-d_isCE'63'_60 ::
+d_isCE'63'_72 ::
   MAlonzo.Code.Agda.Primitive.T_Level_18 ->
-  () -> T_ProofOrCE_38 -> Bool
-d_isCE'63'_60 ~v0 ~v1 v2 = du_isCE'63'_60 v2
-du_isCE'63'_60 :: T_ProofOrCE_38 -> Bool
-du_isCE'63'_60 v0
+  () -> T_ProofOrCE_50 -> Bool
+d_isCE'63'_72 ~v0 ~v1 v2 = du_isCE'63'_72 v2
+du_isCE'63'_72 :: T_ProofOrCE_50 -> Bool
+du_isCE'63'_72 v0
   = coe
       MAlonzo.Code.Data.Bool.Base.d_not_22
-      (coe du_isProof'63'_56 (coe v0))
+      (coe du_isProof'63'_68 (coe v0))
 -- VerifiedCompilation.Certificate.Proof?
-d_Proof'63'_66 a0 a1 = ()
-data T_Proof'63'_66
-  = C_proof_72 AgdaAny |
-    C_abort_78 (MAlonzo.Code.Utils.T_Either_6
+d_Proof'63'_78 a0 a1 = ()
+data T_Proof'63'_78
+  = C_proof_84 AgdaAny |
+    C_abort_90 (MAlonzo.Code.Utils.T_Either_6
                   MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
                   MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
                AgdaAny AgdaAny
 -- VerifiedCompilation.Certificate._>>=_
-d__'62''62''61'__88 ::
+d__'62''62''61'__100 ::
   MAlonzo.Code.Agda.Primitive.T_Level_18 ->
   MAlonzo.Code.Agda.Primitive.T_Level_18 ->
   () ->
   () ->
-  T_Proof'63'_66 -> (AgdaAny -> T_Proof'63'_66) -> T_Proof'63'_66
-d__'62''62''61'__88 ~v0 ~v1 ~v2 ~v3 v4 v5
-  = du__'62''62''61'__88 v4 v5
-du__'62''62''61'__88 ::
-  T_Proof'63'_66 -> (AgdaAny -> T_Proof'63'_66) -> T_Proof'63'_66
-du__'62''62''61'__88 v0 v1
+  T_Proof'63'_78 -> (AgdaAny -> T_Proof'63'_78) -> T_Proof'63'_78
+d__'62''62''61'__100 ~v0 ~v1 ~v2 ~v3 v4 v5
+  = du__'62''62''61'__100 v4 v5
+du__'62''62''61'__100 ::
+  T_Proof'63'_78 -> (AgdaAny -> T_Proof'63'_78) -> T_Proof'63'_78
+du__'62''62''61'__100 v0 v1
   = case coe v0 of
-      C_proof_72 v2 -> coe v1 v2
-      C_abort_78 v4 v5 v6 -> coe C_abort_78 v4 v5 v6
+      C_proof_84 v2 -> coe v1 v2
+      C_abort_90 v4 v5 v6 -> coe C_abort_90 v4 v5 v6
       _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.Certificate.DecidableCE
-d_DecidableCE_108 ::
+d_DecidableCE_120 ::
   () ->
   () ->
   MAlonzo.Code.Agda.Primitive.T_Level_18 ->
   (AgdaAny -> AgdaAny -> ()) -> ()
-d_DecidableCE_108 = erased
+d_DecidableCE_120 = erased
 -- VerifiedCompilation.Certificate.Checkable
-d_Checkable_126 :: () -> () -> (AgdaAny -> AgdaAny -> ()) -> ()
-d_Checkable_126 = erased
+d_Checkable_138 :: () -> () -> (AgdaAny -> AgdaAny -> ()) -> ()
+d_Checkable_138 = erased
 -- VerifiedCompilation.Certificate.Certifiable
-d_Certifiable_142 :: () -> (AgdaAny -> AgdaAny -> ()) -> ()
-d_Certifiable_142 = erased
+d_Certifiable_154 :: () -> (AgdaAny -> AgdaAny -> ()) -> ()
+d_Certifiable_154 = erased
 -- VerifiedCompilation.Certificate.checker
-d_checker_156 ::
+d_checker_168 ::
   () ->
   (AgdaAny -> AgdaAny -> ()) ->
-  (AgdaAny -> AgdaAny -> T_Proof'63'_66) ->
+  (AgdaAny -> AgdaAny -> T_Proof'63'_78) ->
   AgdaAny -> AgdaAny -> T_CertResult_12
-d_checker_156 ~v0 ~v1 v2 v3 v4 = du_checker_156 v2 v3 v4
-du_checker_156 ::
-  (AgdaAny -> AgdaAny -> T_Proof'63'_66) ->
+d_checker_168 ~v0 ~v1 v2 v3 v4 = du_checker_168 v2 v3 v4
+du_checker_168 ::
+  (AgdaAny -> AgdaAny -> T_Proof'63'_78) ->
   AgdaAny -> AgdaAny -> T_CertResult_12
-du_checker_156 v0 v1 v2
+du_checker_168 v0 v1 v2
   = let v3 = coe v0 v1 v2 in
     coe
       (case coe v3 of
-         C_proof_72 v4 -> coe C_proof_18 (coe v4)
-         C_abort_78 v6 v7 v8 -> coe C_abort_32 v6 v7 v8
+         C_proof_84 v4 -> coe C_proof_18 (coe v4)
+         C_abort_90 v6 v7 v8 -> coe C_abort_32 v6 v7 v8
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- VerifiedCompilation.Certificate.decider
-d_decider_192 ::
+d_decider_204 ::
   () ->
   (AgdaAny -> AgdaAny -> ()) ->
-  (AgdaAny -> AgdaAny -> T_ProofOrCE_38) ->
+  (AgdaAny -> AgdaAny -> T_ProofOrCE_50) ->
   AgdaAny -> AgdaAny -> T_CertResult_12
-d_decider_192 ~v0 ~v1 v2 v3 v4 = du_decider_192 v2 v3 v4
-du_decider_192 ::
-  (AgdaAny -> AgdaAny -> T_ProofOrCE_38) ->
+d_decider_204 ~v0 ~v1 v2 v3 v4 = du_decider_204 v2 v3 v4
+du_decider_204 ::
+  (AgdaAny -> AgdaAny -> T_ProofOrCE_50) ->
   AgdaAny -> AgdaAny -> T_CertResult_12
-du_decider_192 v0 v1 v2
+du_decider_204 v0 v1 v2
   = let v3 = coe v0 v1 v2 in
     coe
       (case coe v3 of
-         C_proof_44 v4 -> coe C_proof_18 (coe v4)
-         C_ce_52 v7 v8 v9 -> coe C_ce_26 v7 v8 v9
+         C_proof_56 v4 -> coe C_proof_18 (coe v4)
+         C_ce_64 v7 v8 v9 -> coe C_ce_26 v7 v8 v9
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- VerifiedCompilation.Certificate.decToPCE
-d_decToPCE_234 ::
+d_decToPCE_246 ::
   () ->
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20 ->
-  AgdaAny -> AgdaAny -> T_ProofOrCE_38
-d_decToPCE_234 ~v0 ~v1 v2 v3 v4 v5 = du_decToPCE_234 v2 v3 v4 v5
-du_decToPCE_234 ::
+  AgdaAny -> AgdaAny -> T_ProofOrCE_50
+d_decToPCE_246 ~v0 ~v1 v2 v3 v4 v5 = du_decToPCE_246 v2 v3 v4 v5
+du_decToPCE_246 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20 ->
-  AgdaAny -> AgdaAny -> T_ProofOrCE_38
-du_decToPCE_234 v0 v1 v2 v3
+  AgdaAny -> AgdaAny -> T_ProofOrCE_50
+du_decToPCE_246 v0 v1 v2 v3
   = case coe v1 of
       MAlonzo.Code.Relation.Nullary.Decidable.Core.C__because__32 v4 v5
         -> if coe v4
              then case coe v5 of
                     MAlonzo.Code.Relation.Nullary.Reflects.C_of'696'_22 v6
-                      -> coe C_proof_44 (coe v6)
+                      -> coe C_proof_56 (coe v6)
                     _ -> MAlonzo.RTE.mazUnreachableError
-             else coe seq (coe v5) (coe C_ce_52 v0 v2 v3)
+             else coe seq (coe v5) (coe C_ce_64 v0 v2 v3)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.Certificate.pceToDec
-d_pceToDec_248 ::
+d_pceToDec_260 ::
   () ->
-  T_ProofOrCE_38 ->
+  T_ProofOrCE_50 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_pceToDec_248 ~v0 v1 = du_pceToDec_248 v1
-du_pceToDec_248 ::
-  T_ProofOrCE_38 ->
+d_pceToDec_260 ~v0 v1 = du_pceToDec_260 v1
+du_pceToDec_260 ::
+  T_ProofOrCE_50 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_pceToDec_248 v0
+du_pceToDec_260 v0
   = case coe v0 of
-      C_proof_44 v1
+      C_proof_56 v1
         -> coe
              MAlonzo.Code.Relation.Nullary.Decidable.Core.C__because__32
              (coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10)
              (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'696'_22 (coe v1))
-      C_ce_52 v4 v5 v6
+      C_ce_64 v4 v5 v6
         -> coe
              MAlonzo.Code.Relation.Nullary.Decidable.Core.C__because__32
              (coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8)
              (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.Certificate.matchOrCE
-d_matchOrCE_262 ::
+d_matchOrCE_274 ::
   () ->
   () ->
   MAlonzo.Code.Agda.Primitive.T_Level_18 ->
@@ -199,18 +222,18 @@ d_matchOrCE_262 ::
   (AgdaAny ->
    AgdaAny ->
    MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20) ->
-  AgdaAny -> AgdaAny -> T_ProofOrCE_38
-d_matchOrCE_262 ~v0 ~v1 ~v2 ~v3 v4 v5 v6 v7
-  = du_matchOrCE_262 v4 v5 v6 v7
-du_matchOrCE_262 ::
+  AgdaAny -> AgdaAny -> T_ProofOrCE_50
+d_matchOrCE_274 ~v0 ~v1 ~v2 ~v3 v4 v5 v6 v7
+  = du_matchOrCE_274 v4 v5 v6 v7
+du_matchOrCE_274 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   (AgdaAny ->
    AgdaAny ->
    MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20) ->
-  AgdaAny -> AgdaAny -> T_ProofOrCE_38
-du_matchOrCE_262 v0 v1 v2 v3
+  AgdaAny -> AgdaAny -> T_ProofOrCE_50
+du_matchOrCE_274 v0 v1 v2 v3
   = let v4 = coe v1 v2 v3 in
     coe
       (case coe v4 of
@@ -218,12 +241,12 @@ du_matchOrCE_262 v0 v1 v2 v3
            -> if coe v5
                 then case coe v6 of
                        MAlonzo.Code.Relation.Nullary.Reflects.C_of'696'_22 v7
-                         -> coe C_proof_44 (coe v7)
+                         -> coe C_proof_56 (coe v7)
                        _ -> MAlonzo.RTE.mazUnreachableError
-                else coe seq (coe v6) (coe C_ce_52 v0 v2 v3)
+                else coe seq (coe v6) (coe C_ce_64 v0 v2 v3)
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- VerifiedCompilation.Certificate.pcePointwise
-d_pcePointwise_304 ::
+d_pcePointwise_316 ::
   () ->
   () ->
   MAlonzo.Code.Agda.Primitive.T_Level_18 ->
@@ -231,48 +254,48 @@ d_pcePointwise_304 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
-  (AgdaAny -> AgdaAny -> T_ProofOrCE_38) ->
-  [AgdaAny] -> [AgdaAny] -> T_ProofOrCE_38
-d_pcePointwise_304 ~v0 ~v1 ~v2 ~v3 v4 v5 v6 v7
-  = du_pcePointwise_304 v4 v5 v6 v7
-du_pcePointwise_304 ::
+  (AgdaAny -> AgdaAny -> T_ProofOrCE_50) ->
+  [AgdaAny] -> [AgdaAny] -> T_ProofOrCE_50
+d_pcePointwise_316 ~v0 ~v1 ~v2 ~v3 v4 v5 v6 v7
+  = du_pcePointwise_316 v4 v5 v6 v7
+du_pcePointwise_316 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
-  (AgdaAny -> AgdaAny -> T_ProofOrCE_38) ->
-  [AgdaAny] -> [AgdaAny] -> T_ProofOrCE_38
-du_pcePointwise_304 v0 v1 v2 v3
+  (AgdaAny -> AgdaAny -> T_ProofOrCE_50) ->
+  [AgdaAny] -> [AgdaAny] -> T_ProofOrCE_50
+du_pcePointwise_316 v0 v1 v2 v3
   = case coe v2 of
       []
         -> case coe v3 of
              []
                -> coe
-                    C_proof_44
+                    C_proof_56
                     (coe
                        MAlonzo.Code.Data.List.Relation.Binary.Pointwise.Base.C_'91''93'_56)
-             (:) v4 v5 -> coe C_ce_52 v0 v2 v5
+             (:) v4 v5 -> coe C_ce_64 v0 v2 v5
              _ -> MAlonzo.RTE.mazUnreachableError
       (:) v4 v5
         -> case coe v3 of
-             [] -> coe C_ce_52 v0 v5 v3
+             [] -> coe C_ce_64 v0 v5 v3
              (:) v6 v7
                -> let v8 = coe v1 v4 v6 in
                   coe
                     (case coe v8 of
-                       C_proof_44 v9
+                       C_proof_56 v9
                          -> let v10
-                                  = coe du_pcePointwise_304 (coe v0) (coe v1) (coe v5) (coe v7) in
+                                  = coe du_pcePointwise_316 (coe v0) (coe v1) (coe v5) (coe v7) in
                             coe
                               (case coe v10 of
-                                 C_proof_44 v11
+                                 C_proof_56 v11
                                    -> coe
-                                        C_proof_44
+                                        C_proof_56
                                         (coe
                                            MAlonzo.Code.Data.List.Relation.Binary.Pointwise.Base.C__'8759'__62
                                            v9 v11)
-                                 C_ce_52 v14 v15 v16 -> coe C_ce_52 v14 v15 v16
+                                 C_ce_64 v14 v15 v16 -> coe C_ce_64 v14 v15 v16
                                  _ -> MAlonzo.RTE.mazUnreachableError)
-                       C_ce_52 v12 v13 v14 -> coe C_ce_52 v12 v13 v14
+                       C_ce_64 v12 v13 v14 -> coe C_ce_64 v12 v13 v14
                        _ -> MAlonzo.RTE.mazUnreachableError)
              _ -> MAlonzo.RTE.mazUnreachableError
       _ -> MAlonzo.RTE.mazUnreachableError

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/FloatOut.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/FloatOut.hs
@@ -540,7 +540,7 @@ d_decide_312 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_decide_312 v0 v1 v2
   = let v3 = coe d_dec_304 v0 v1 v2 in
     coe
@@ -550,12 +550,12 @@ d_decide_312 v0 v1 v2
                 then case coe v5 of
                        MAlonzo.Code.Relation.Nullary.Reflects.C_of'696'_22 v6
                          -> coe
-                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 (coe v6)
+                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 (coe v6)
                        _ -> MAlonzo.RTE.mazUnreachableError
                 else coe
                        seq (coe v5)
                        (coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_LetFloatOutT_44 v1 v2)
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- VerifiedCompilation.FloatOut.numSites

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UApplyToCase.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UApplyToCase.hs
@@ -39,7 +39,7 @@ d_a2c'63''7580''7580'_24 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_a2c'63''7580''7580'_24 v0
   = coe
       MAlonzo.Code.VerifiedCompilation.UntypedTranslation.du_translation'63'_160
@@ -51,7 +51,7 @@ d_a2c'63'_32 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_a2c'63'_32 v0 v1 v2
   = let v3
           = coe
@@ -74,31 +74,31 @@ d_a2c'63'_32 v0 v1 v2
          (case coe v2 of
             MAlonzo.Code.Untyped.C_'96'_18 v5
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_42 v1 v2
             MAlonzo.Code.Untyped.C_ƛ_20 v5
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_42 v1 v2
             MAlonzo.Code.Untyped.C__'183'__22 v5 v6
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_42 v1 v2
             MAlonzo.Code.Untyped.C_force_24 v5
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_42 v1 v2
             MAlonzo.Code.Untyped.C_delay_26 v5
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_42 v1 v2
             MAlonzo.Code.Untyped.C_con_28 v5
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_42 v1 v2
             MAlonzo.Code.Untyped.C_constr_34 v5 v6
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_42 v1 v2
             MAlonzo.Code.Untyped.C_case_40 v5 v6
               -> let v7
@@ -144,15 +144,15 @@ d_a2c'63'_32 v0 v1 v2
                                                                                             coe
                                                                                               (case coe
                                                                                                       v29 of
-                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v30
+                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v30
                                                                                                    -> coe
-                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                         (coe
                                                                                                            C_a2c_16
                                                                                                            v30)
-                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v33 v34 v35
+                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v33 v34 v35
                                                                                                    -> coe
-                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                         v33
                                                                                                         v34
                                                                                                         v35
@@ -217,15 +217,15 @@ d_a2c'63'_32 v0 v1 v2
                                                                                                               coe
                                                                                                                 (case coe
                                                                                                                         v34 of
-                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v35
+                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v35
                                                                                                                      -> coe
-                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                           (coe
                                                                                                                              C_a2c_16
                                                                                                                              v35)
-                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v38 v39 v40
+                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v38 v39 v40
                                                                                                                      -> coe
-                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                           v38
                                                                                                                           v39
                                                                                                                           v40
@@ -240,18 +240,18 @@ d_a2c'63'_32 v0 v1 v2
                                                else coe
                                                       seq (coe v12)
                                                       (coe
-                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_42
                                                          v1 v2)
                                         _ -> MAlonzo.RTE.mazUnreachableError))
                       _ -> MAlonzo.RTE.mazUnreachableError)
             MAlonzo.Code.Untyped.C_builtin_44 v5
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_42 v1 v2
             MAlonzo.Code.Untyped.C_error_46
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_42 v1 v2
             _ -> MAlonzo.RTE.mazUnreachableError))
 -- VerifiedCompilation.UApplyToCase..extendedlambda0

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCSE.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCSE.hs
@@ -50,7 +50,7 @@ d_isUntypedCSE'63'_22 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_isUntypedCSE'63'_22 v0
   = coe
       MAlonzo.Code.VerifiedCompilation.UntypedTranslation.du_translation'63'_160
@@ -61,7 +61,7 @@ d_isUCSE'63'_24 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_isUCSE'63'_24 v0 v1 v2
   = let v3
           = \ v3 ->
@@ -74,17 +74,17 @@ d_isUCSE'63'_24 v0 v1 v2
          (case coe v2 of
             MAlonzo.Code.Untyped.C_'96'_18 v5
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
             MAlonzo.Code.Untyped.C_ƛ_20 v5
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
             MAlonzo.Code.Untyped.C__'183'__22 v5 v6
               -> case coe v5 of
                    MAlonzo.Code.Untyped.C_'96'_18 v7
                      -> coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
                    MAlonzo.Code.Untyped.C_ƛ_20 v7
                      -> let v8
@@ -178,16 +178,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                     coe
                                                                                                                       (case coe
                                                                                                                               v23 of
-                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v24
+                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v24
                                                                                                                            -> coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                 (coe
                                                                                                                                    C_cse_14
                                                                                                                                    v22
                                                                                                                                    v24)
-                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v27 v28 v29
+                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v27 v28 v29
                                                                                                                            -> coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 v27
                                                                                                                                 v28
                                                                                                                                 v29
@@ -198,7 +198,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                (coe
                                                                                                                   v21)
                                                                                                                (coe
-                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                   v1
                                                                                                                   v2)
@@ -290,16 +290,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                              coe
                                                                                                                                                (case coe
                                                                                                                                                        v28 of
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v29
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v29
                                                                                                                                                     -> coe
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                          (coe
                                                                                                                                                             C_cse_14
                                                                                                                                                             v27
                                                                                                                                                             v29)
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v32 v33 v34
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v32 v33 v34
                                                                                                                                                     -> coe
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                          v32
                                                                                                                                                          v33
                                                                                                                                                          v34
@@ -310,7 +310,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                         (coe
                                                                                                                                            v26)
                                                                                                                                         (coe
-                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                            v1
                                                                                                                                            v2)
@@ -351,16 +351,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                 coe
                                                                                                                                   (case coe
                                                                                                                                           v25 of
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v26
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v26
                                                                                                                                        -> coe
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                             (coe
                                                                                                                                                C_cse_14
                                                                                                                                                v24
                                                                                                                                                v26)
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v29 v30 v31
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v29 v30 v31
                                                                                                                                        -> coe
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                             v29
                                                                                                                                             v30
                                                                                                                                             v31
@@ -371,7 +371,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                            (coe
                                                                                                                               v23)
                                                                                                                            (coe
-                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                               MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                               v1
                                                                                                                               v2)
@@ -384,7 +384,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                       (coe
                                                                          MAlonzo.Code.Agda.Builtin.Bool.C_false_8)
                                                                       (coe
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                          v1 v2)
                                                                MAlonzo.Code.Untyped.C__'183'__22 v14 v15
@@ -571,16 +571,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   coe
                                                                                                                                     (case coe
                                                                                                                                             v27 of
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                               (coe
                                                                                                                                                  C_cse_14
                                                                                                                                                  v26
                                                                                                                                                  v28)
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                               v31
                                                                                                                                               v32
                                                                                                                                               v33
@@ -591,7 +591,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                              (coe
                                                                                                                                 v25)
                                                                                                                              (coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                 v1
                                                                                                                                 v2)
@@ -784,16 +784,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v32 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v31
                                                                                                                                                                    v33)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v36
                                                                                                                                                                 v37
                                                                                                                                                                 v38
@@ -804,7 +804,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v30)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -845,16 +845,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                        coe
                                                                                                                                          (case coe
                                                                                                                                                  v27 of
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                    (coe
                                                                                                                                                       C_cse_14
                                                                                                                                                       v26
                                                                                                                                                       v28)
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                    v31
                                                                                                                                                    v32
                                                                                                                                                    v33
@@ -865,7 +865,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   (coe
                                                                                                                                      v25)
                                                                                                                                   (coe
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                      v1
                                                                                                                                      v2)
@@ -1004,16 +1004,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   coe
                                                                                                                                     (case coe
                                                                                                                                             v27 of
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                               (coe
                                                                                                                                                  C_cse_14
                                                                                                                                                  v26
                                                                                                                                                  v28)
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                               v31
                                                                                                                                               v32
                                                                                                                                               v33
@@ -1024,7 +1024,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                              (coe
                                                                                                                                 v25)
                                                                                                                              (coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                 v1
                                                                                                                                 v2)
@@ -1167,16 +1167,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v32 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v31
                                                                                                                                                                    v33)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v36
                                                                                                                                                                 v37
                                                                                                                                                                 v38
@@ -1187,7 +1187,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v30)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -1232,16 +1232,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                        coe
                                                                                                                                          (case coe
                                                                                                                                                  v27 of
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                    (coe
                                                                                                                                                       C_cse_14
                                                                                                                                                       v26
                                                                                                                                                       v28)
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                    v31
                                                                                                                                                    v32
                                                                                                                                                    v33
@@ -1252,7 +1252,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   (coe
                                                                                                                                      v25)
                                                                                                                                   (coe
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                      v1
                                                                                                                                      v2)
@@ -1441,16 +1441,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   coe
                                                                                                                                     (case coe
                                                                                                                                             v28 of
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v29
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v29
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                               (coe
                                                                                                                                                  C_cse_14
                                                                                                                                                  v27
                                                                                                                                                  v29)
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v32 v33 v34
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v32 v33 v34
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                               v32
                                                                                                                                               v33
                                                                                                                                               v34
@@ -1461,7 +1461,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                              (coe
                                                                                                                                 v26)
                                                                                                                              (coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                 v1
                                                                                                                                 v2)
@@ -1654,16 +1654,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v33 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v32
                                                                                                                                                                    v34)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v37
                                                                                                                                                                 v38
                                                                                                                                                                 v39
@@ -1674,7 +1674,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v31)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -1715,16 +1715,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                        coe
                                                                                                                                          (case coe
                                                                                                                                                  v28 of
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v29
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v29
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                    (coe
                                                                                                                                                       C_cse_14
                                                                                                                                                       v27
                                                                                                                                                       v29)
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v32 v33 v34
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v32 v33 v34
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                    v32
                                                                                                                                                    v33
                                                                                                                                                    v34
@@ -1735,7 +1735,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   (coe
                                                                                                                                      v26)
                                                                                                                                   (coe
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                      v1
                                                                                                                                      v2)
@@ -1924,16 +1924,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   coe
                                                                                                                                     (case coe
                                                                                                                                             v27 of
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                               (coe
                                                                                                                                                  C_cse_14
                                                                                                                                                  v26
                                                                                                                                                  v28)
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                               v31
                                                                                                                                               v32
                                                                                                                                               v33
@@ -1944,7 +1944,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                              (coe
                                                                                                                                 v25)
                                                                                                                              (coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                 v1
                                                                                                                                 v2)
@@ -2137,16 +2137,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v32 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v31
                                                                                                                                                                    v33)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v36
                                                                                                                                                                 v37
                                                                                                                                                                 v38
@@ -2157,7 +2157,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v30)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -2198,16 +2198,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                        coe
                                                                                                                                          (case coe
                                                                                                                                                  v27 of
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                    (coe
                                                                                                                                                       C_cse_14
                                                                                                                                                       v26
                                                                                                                                                       v28)
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                    v31
                                                                                                                                                    v32
                                                                                                                                                    v33
@@ -2218,7 +2218,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   (coe
                                                                                                                                      v25)
                                                                                                                                   (coe
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                      v1
                                                                                                                                      v2)
@@ -2407,16 +2407,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   coe
                                                                                                                                     (case coe
                                                                                                                                             v27 of
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                               (coe
                                                                                                                                                  C_cse_14
                                                                                                                                                  v26
                                                                                                                                                  v28)
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                               v31
                                                                                                                                               v32
                                                                                                                                               v33
@@ -2427,7 +2427,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                              (coe
                                                                                                                                 v25)
                                                                                                                              (coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                 v1
                                                                                                                                 v2)
@@ -2620,16 +2620,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v32 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v31
                                                                                                                                                                    v33)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v36
                                                                                                                                                                 v37
                                                                                                                                                                 v38
@@ -2640,7 +2640,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v30)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -2681,16 +2681,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                        coe
                                                                                                                                          (case coe
                                                                                                                                                  v27 of
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                    (coe
                                                                                                                                                       C_cse_14
                                                                                                                                                       v26
                                                                                                                                                       v28)
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                    v31
                                                                                                                                                    v32
                                                                                                                                                    v33
@@ -2701,7 +2701,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   (coe
                                                                                                                                      v25)
                                                                                                                                   (coe
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                      v1
                                                                                                                                      v2)
@@ -2890,16 +2890,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   coe
                                                                                                                                     (case coe
                                                                                                                                             v27 of
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                               (coe
                                                                                                                                                  C_cse_14
                                                                                                                                                  v26
                                                                                                                                                  v28)
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                               v31
                                                                                                                                               v32
                                                                                                                                               v33
@@ -2910,7 +2910,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                              (coe
                                                                                                                                 v25)
                                                                                                                              (coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                 v1
                                                                                                                                 v2)
@@ -3103,16 +3103,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v32 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v31
                                                                                                                                                                    v33)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v36
                                                                                                                                                                 v37
                                                                                                                                                                 v38
@@ -3123,7 +3123,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v30)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -3164,16 +3164,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                        coe
                                                                                                                                          (case coe
                                                                                                                                                  v27 of
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                    (coe
                                                                                                                                                       C_cse_14
                                                                                                                                                       v26
                                                                                                                                                       v28)
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                    v31
                                                                                                                                                    v32
                                                                                                                                                    v33
@@ -3184,7 +3184,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   (coe
                                                                                                                                      v25)
                                                                                                                                   (coe
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                      v1
                                                                                                                                      v2)
@@ -3373,16 +3373,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   coe
                                                                                                                                     (case coe
                                                                                                                                             v28 of
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v29
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v29
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                               (coe
                                                                                                                                                  C_cse_14
                                                                                                                                                  v27
                                                                                                                                                  v29)
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v32 v33 v34
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v32 v33 v34
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                               v32
                                                                                                                                               v33
                                                                                                                                               v34
@@ -3393,7 +3393,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                              (coe
                                                                                                                                 v26)
                                                                                                                              (coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                 v1
                                                                                                                                 v2)
@@ -3586,16 +3586,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v33 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v32
                                                                                                                                                                    v34)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v37
                                                                                                                                                                 v38
                                                                                                                                                                 v39
@@ -3606,7 +3606,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v31)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -3647,16 +3647,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                        coe
                                                                                                                                          (case coe
                                                                                                                                                  v28 of
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v29
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v29
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                    (coe
                                                                                                                                                       C_cse_14
                                                                                                                                                       v27
                                                                                                                                                       v29)
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v32 v33 v34
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v32 v33 v34
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                    v32
                                                                                                                                                    v33
                                                                                                                                                    v34
@@ -3667,7 +3667,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   (coe
                                                                                                                                      v26)
                                                                                                                                   (coe
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                      v1
                                                                                                                                      v2)
@@ -3856,16 +3856,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   coe
                                                                                                                                     (case coe
                                                                                                                                             v28 of
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v29
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v29
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                               (coe
                                                                                                                                                  C_cse_14
                                                                                                                                                  v27
                                                                                                                                                  v29)
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v32 v33 v34
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v32 v33 v34
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                               v32
                                                                                                                                               v33
                                                                                                                                               v34
@@ -3876,7 +3876,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                              (coe
                                                                                                                                 v26)
                                                                                                                              (coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                 v1
                                                                                                                                 v2)
@@ -4069,16 +4069,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v33 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v32
                                                                                                                                                                    v34)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v37
                                                                                                                                                                 v38
                                                                                                                                                                 v39
@@ -4089,7 +4089,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v31)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -4130,16 +4130,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                        coe
                                                                                                                                          (case coe
                                                                                                                                                  v28 of
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v29
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v29
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                    (coe
                                                                                                                                                       C_cse_14
                                                                                                                                                       v27
                                                                                                                                                       v29)
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v32 v33 v34
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v32 v33 v34
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                    v32
                                                                                                                                                    v33
                                                                                                                                                    v34
@@ -4150,7 +4150,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   (coe
                                                                                                                                      v26)
                                                                                                                                   (coe
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                      v1
                                                                                                                                      v2)
@@ -4339,16 +4339,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   coe
                                                                                                                                     (case coe
                                                                                                                                             v27 of
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                               (coe
                                                                                                                                                  C_cse_14
                                                                                                                                                  v26
                                                                                                                                                  v28)
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                               v31
                                                                                                                                               v32
                                                                                                                                               v33
@@ -4359,7 +4359,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                              (coe
                                                                                                                                 v25)
                                                                                                                              (coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                 v1
                                                                                                                                 v2)
@@ -4552,16 +4552,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v32 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v31
                                                                                                                                                                    v33)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v36
                                                                                                                                                                 v37
                                                                                                                                                                 v38
@@ -4572,7 +4572,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v30)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -4613,16 +4613,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                        coe
                                                                                                                                          (case coe
                                                                                                                                                  v27 of
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                    (coe
                                                                                                                                                       C_cse_14
                                                                                                                                                       v26
                                                                                                                                                       v28)
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                    v31
                                                                                                                                                    v32
                                                                                                                                                    v33
@@ -4633,7 +4633,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   (coe
                                                                                                                                      v25)
                                                                                                                                   (coe
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                      v1
                                                                                                                                      v2)
@@ -4822,16 +4822,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   coe
                                                                                                                                     (case coe
                                                                                                                                             v26 of
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v27
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v27
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                               (coe
                                                                                                                                                  C_cse_14
                                                                                                                                                  v25
                                                                                                                                                  v27)
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v30 v31 v32
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v30 v31 v32
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                               v30
                                                                                                                                               v31
                                                                                                                                               v32
@@ -4842,7 +4842,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                              (coe
                                                                                                                                 v24)
                                                                                                                              (coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                 v1
                                                                                                                                 v2)
@@ -5035,16 +5035,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v31 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v32
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v32
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v30
                                                                                                                                                                    v32)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v35 v36 v37
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v35 v36 v37
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v35
                                                                                                                                                                 v36
                                                                                                                                                                 v37
@@ -5055,7 +5055,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v29)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -5096,16 +5096,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                        coe
                                                                                                                                          (case coe
                                                                                                                                                  v26 of
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v27
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v27
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                    (coe
                                                                                                                                                       C_cse_14
                                                                                                                                                       v25
                                                                                                                                                       v27)
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v30 v31 v32
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v30 v31 v32
                                                                                                                                               -> coe
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                    v30
                                                                                                                                                    v31
                                                                                                                                                    v32
@@ -5116,7 +5116,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                   (coe
                                                                                                                                      v24)
                                                                                                                                   (coe
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                      v1
                                                                                                                                      v2)
@@ -5205,16 +5205,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                     coe
                                                                                                                       (case coe
                                                                                                                               v23 of
-                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v24
+                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v24
                                                                                                                            -> coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                 (coe
                                                                                                                                    C_cse_14
                                                                                                                                    v22
                                                                                                                                    v24)
-                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v27 v28 v29
+                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v27 v28 v29
                                                                                                                            -> coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 v27
                                                                                                                                 v28
                                                                                                                                 v29
@@ -5225,7 +5225,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                (coe
                                                                                                                   v21)
                                                                                                                (coe
-                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                   v1
                                                                                                                   v2)
@@ -5324,16 +5324,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                              coe
                                                                                                                                                (case coe
                                                                                                                                                        v28 of
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v29
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v29
                                                                                                                                                     -> coe
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                          (coe
                                                                                                                                                             C_cse_14
                                                                                                                                                             v27
                                                                                                                                                             v29)
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v32 v33 v34
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v32 v33 v34
                                                                                                                                                     -> coe
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                          v32
                                                                                                                                                          v33
                                                                                                                                                          v34
@@ -5344,7 +5344,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                         (coe
                                                                                                                                            v26)
                                                                                                                                         (coe
-                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                            v1
                                                                                                                                            v2)
@@ -5385,16 +5385,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                 coe
                                                                                                                                   (case coe
                                                                                                                                           v25 of
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v26
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v26
                                                                                                                                        -> coe
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                             (coe
                                                                                                                                                C_cse_14
                                                                                                                                                v24
                                                                                                                                                v26)
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v29 v30 v31
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v29 v30 v31
                                                                                                                                        -> coe
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                             v29
                                                                                                                                             v30
                                                                                                                                             v31
@@ -5405,7 +5405,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                            (coe
                                                                                                                               v23)
                                                                                                                            (coe
-                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                               MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                               v1
                                                                                                                               v2)
@@ -5418,7 +5418,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                       (coe
                                                                          MAlonzo.Code.Agda.Builtin.Bool.C_false_8)
                                                                       (coe
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                          v1 v2)
                                                                MAlonzo.Code.Untyped.C_con_28 v14
@@ -5427,7 +5427,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                       (coe
                                                                          MAlonzo.Code.Agda.Builtin.Bool.C_false_8)
                                                                       (coe
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                          v1 v2)
                                                                MAlonzo.Code.Untyped.C_constr_34 v14 v15
@@ -5518,16 +5518,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                            coe
                                                                                                                              (case coe
                                                                                                                                      v26 of
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v27
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v27
                                                                                                                                   -> coe
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                        (coe
                                                                                                                                           C_cse_14
                                                                                                                                           v25
                                                                                                                                           v27)
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v30 v31 v32
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v30 v31 v32
                                                                                                                                   -> coe
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                        v30
                                                                                                                                        v31
                                                                                                                                        v32
@@ -5538,7 +5538,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                       (coe
                                                                                                                          v24)
                                                                                                                       (coe
-                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                          v1
                                                                                                                          v2)
@@ -5638,16 +5638,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                              coe
                                                                                                                                                (case coe
                                                                                                                                                        v31 of
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v32
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v32
                                                                                                                                                     -> coe
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                          (coe
                                                                                                                                                             C_cse_14
                                                                                                                                                             v30
                                                                                                                                                             v32)
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v35 v36 v37
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v35 v36 v37
                                                                                                                                                     -> coe
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                          v35
                                                                                                                                                          v36
                                                                                                                                                          v37
@@ -5658,7 +5658,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                         (coe
                                                                                                                                            v29)
                                                                                                                                         (coe
-                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                            v1
                                                                                                                                            v2)
@@ -5699,16 +5699,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                 coe
                                                                                                                                   (case coe
                                                                                                                                           v26 of
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v27
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v27
                                                                                                                                        -> coe
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                             (coe
                                                                                                                                                C_cse_14
                                                                                                                                                v25
                                                                                                                                                v27)
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v30 v31 v32
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v30 v31 v32
                                                                                                                                        -> coe
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                             v30
                                                                                                                                             v31
                                                                                                                                             v32
@@ -5719,7 +5719,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                            (coe
                                                                                                                               v24)
                                                                                                                            (coe
-                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                               MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                               v1
                                                                                                                               v2)
@@ -5814,16 +5814,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                            coe
                                                                                                                              (case coe
                                                                                                                                      v26 of
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v27
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v27
                                                                                                                                   -> coe
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                        (coe
                                                                                                                                           C_cse_14
                                                                                                                                           v25
                                                                                                                                           v27)
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v30 v31 v32
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v30 v31 v32
                                                                                                                                   -> coe
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                        v30
                                                                                                                                        v31
                                                                                                                                        v32
@@ -5834,7 +5834,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                       (coe
                                                                                                                          v24)
                                                                                                                       (coe
-                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                          v1
                                                                                                                          v2)
@@ -5934,16 +5934,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                              coe
                                                                                                                                                (case coe
                                                                                                                                                        v31 of
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v32
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v32
                                                                                                                                                     -> coe
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                          (coe
                                                                                                                                                             C_cse_14
                                                                                                                                                             v30
                                                                                                                                                             v32)
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v35 v36 v37
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v35 v36 v37
                                                                                                                                                     -> coe
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                          v35
                                                                                                                                                          v36
                                                                                                                                                          v37
@@ -5954,7 +5954,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                         (coe
                                                                                                                                            v29)
                                                                                                                                         (coe
-                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                            v1
                                                                                                                                            v2)
@@ -5995,16 +5995,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                 coe
                                                                                                                                   (case coe
                                                                                                                                           v26 of
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v27
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v27
                                                                                                                                        -> coe
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                             (coe
                                                                                                                                                C_cse_14
                                                                                                                                                v25
                                                                                                                                                v27)
-                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v30 v31 v32
+                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v30 v31 v32
                                                                                                                                        -> coe
-                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                             v30
                                                                                                                                             v31
                                                                                                                                             v32
@@ -6015,7 +6015,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                            (coe
                                                                                                                               v24)
                                                                                                                            (coe
-                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                               MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                               v1
                                                                                                                               v2)
@@ -6028,7 +6028,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                       (coe
                                                                          MAlonzo.Code.Agda.Builtin.Bool.C_false_8)
                                                                       (coe
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                          v1 v2)
                                                                MAlonzo.Code.Untyped.C_error_46
@@ -6037,7 +6037,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                       (coe
                                                                          MAlonzo.Code.Agda.Builtin.Bool.C_false_8)
                                                                       (coe
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                          v1 v2)
                                                                _ -> MAlonzo.RTE.mazUnreachableError))
@@ -6141,16 +6141,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                       coe
                                                                                                                                         (case coe
                                                                                                                                                 v28 of
-                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v29
+                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v29
                                                                                                                                              -> coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                   (coe
                                                                                                                                                      C_cse_14
                                                                                                                                                      v27
                                                                                                                                                      v29)
-                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v32 v33 v34
+                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v32 v33 v34
                                                                                                                                              -> coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   v32
                                                                                                                                                   v33
                                                                                                                                                   v34
@@ -6161,7 +6161,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                  (coe
                                                                                                                                     v26)
                                                                                                                                  (coe
-                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                     v1
                                                                                                                                     v2)
@@ -6253,16 +6253,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                coe
                                                                                                                                                                  (case coe
                                                                                                                                                                          v33 of
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                                                                       -> coe
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                            (coe
                                                                                                                                                                               C_cse_14
                                                                                                                                                                               v32
                                                                                                                                                                               v34)
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                                                                       -> coe
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                            v37
                                                                                                                                                                            v38
                                                                                                                                                                            v39
@@ -6273,7 +6273,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                           (coe
                                                                                                                                                              v31)
                                                                                                                                                           (coe
-                                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                              v1
                                                                                                                                                              v2)
@@ -6314,16 +6314,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                   coe
                                                                                                                                                     (case coe
                                                                                                                                                             v30 of
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v31
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v31
                                                                                                                                                          -> coe
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                               (coe
                                                                                                                                                                  C_cse_14
                                                                                                                                                                  v29
                                                                                                                                                                  v31)
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v34 v35 v36
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v34 v35 v36
                                                                                                                                                          -> coe
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                               v34
                                                                                                                                                               v35
                                                                                                                                                               v36
@@ -6334,7 +6334,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                              (coe
                                                                                                                                                 v28)
                                                                                                                                              (coe
-                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                 v1
                                                                                                                                                 v2)
@@ -6345,7 +6345,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                    -> coe
                                                                                         seq (coe v9)
                                                                                         (coe
-                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                            v1 v2)
                                                                                  MAlonzo.Code.Untyped.C__'183'__22 v19 v20
@@ -6535,16 +6535,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v32 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v31
                                                                                                                                                                    v33)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v36
                                                                                                                                                                 v37
                                                                                                                                                                 v38
@@ -6555,7 +6555,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v30)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -6748,16 +6748,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                       coe
                                                                                                                                                                         (case coe
                                                                                                                                                                                 v37 of
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v38
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v38
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                   (coe
                                                                                                                                                                                      C_cse_14
                                                                                                                                                                                      v36
                                                                                                                                                                                      v38)
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v41 v42 v43
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v41 v42 v43
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                   v41
                                                                                                                                                                                   v42
                                                                                                                                                                                   v43
@@ -6768,7 +6768,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                  (coe
                                                                                                                                                                     v35)
                                                                                                                                                                  (coe
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                                     v1
                                                                                                                                                                     v2)
@@ -6809,16 +6809,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                          coe
                                                                                                                                                            (case coe
                                                                                                                                                                    v32 of
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                      (coe
                                                                                                                                                                         C_cse_14
                                                                                                                                                                         v31
                                                                                                                                                                         v33)
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                      v36
                                                                                                                                                                      v37
                                                                                                                                                                      v38
@@ -6829,7 +6829,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     (coe
                                                                                                                                                        v30)
                                                                                                                                                     (coe
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                        v1
                                                                                                                                                        v2)
@@ -6970,16 +6970,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v32 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v31
                                                                                                                                                                    v33)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v36
                                                                                                                                                                 v37
                                                                                                                                                                 v38
@@ -6990,7 +6990,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v30)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -7133,16 +7133,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                       coe
                                                                                                                                                                         (case coe
                                                                                                                                                                                 v37 of
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v38
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v38
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                   (coe
                                                                                                                                                                                      C_cse_14
                                                                                                                                                                                      v36
                                                                                                                                                                                      v38)
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v41 v42 v43
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v41 v42 v43
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                   v41
                                                                                                                                                                                   v42
                                                                                                                                                                                   v43
@@ -7153,7 +7153,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                  (coe
                                                                                                                                                                     v35)
                                                                                                                                                                  (coe
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                                     v1
                                                                                                                                                                     v2)
@@ -7198,16 +7198,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                          coe
                                                                                                                                                            (case coe
                                                                                                                                                                    v32 of
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                      (coe
                                                                                                                                                                         C_cse_14
                                                                                                                                                                         v31
                                                                                                                                                                         v33)
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                      v36
                                                                                                                                                                      v37
                                                                                                                                                                      v38
@@ -7218,7 +7218,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     (coe
                                                                                                                                                        v30)
                                                                                                                                                     (coe
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                        v1
                                                                                                                                                        v2)
@@ -7409,16 +7409,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v33 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v32
                                                                                                                                                                    v34)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v37
                                                                                                                                                                 v38
                                                                                                                                                                 v39
@@ -7429,7 +7429,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v31)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -7622,16 +7622,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                       coe
                                                                                                                                                                         (case coe
                                                                                                                                                                                 v38 of
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v39
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v39
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                   (coe
                                                                                                                                                                                      C_cse_14
                                                                                                                                                                                      v37
                                                                                                                                                                                      v39)
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v42 v43 v44
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v42 v43 v44
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                   v42
                                                                                                                                                                                   v43
                                                                                                                                                                                   v44
@@ -7642,7 +7642,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                  (coe
                                                                                                                                                                     v36)
                                                                                                                                                                  (coe
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                                     v1
                                                                                                                                                                     v2)
@@ -7683,16 +7683,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                          coe
                                                                                                                                                            (case coe
                                                                                                                                                                    v33 of
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                      (coe
                                                                                                                                                                         C_cse_14
                                                                                                                                                                         v32
                                                                                                                                                                         v34)
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                      v37
                                                                                                                                                                      v38
                                                                                                                                                                      v39
@@ -7703,7 +7703,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     (coe
                                                                                                                                                        v31)
                                                                                                                                                     (coe
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                        v1
                                                                                                                                                        v2)
@@ -7894,16 +7894,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v32 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v31
                                                                                                                                                                    v33)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v36
                                                                                                                                                                 v37
                                                                                                                                                                 v38
@@ -7914,7 +7914,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v30)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -8107,16 +8107,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                       coe
                                                                                                                                                                         (case coe
                                                                                                                                                                                 v37 of
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v38
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v38
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                   (coe
                                                                                                                                                                                      C_cse_14
                                                                                                                                                                                      v36
                                                                                                                                                                                      v38)
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v41 v42 v43
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v41 v42 v43
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                   v41
                                                                                                                                                                                   v42
                                                                                                                                                                                   v43
@@ -8127,7 +8127,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                  (coe
                                                                                                                                                                     v35)
                                                                                                                                                                  (coe
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                                     v1
                                                                                                                                                                     v2)
@@ -8168,16 +8168,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                          coe
                                                                                                                                                            (case coe
                                                                                                                                                                    v32 of
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                      (coe
                                                                                                                                                                         C_cse_14
                                                                                                                                                                         v31
                                                                                                                                                                         v33)
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                      v36
                                                                                                                                                                      v37
                                                                                                                                                                      v38
@@ -8188,7 +8188,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     (coe
                                                                                                                                                        v30)
                                                                                                                                                     (coe
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                        v1
                                                                                                                                                        v2)
@@ -8379,16 +8379,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v32 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v31
                                                                                                                                                                    v33)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v36
                                                                                                                                                                 v37
                                                                                                                                                                 v38
@@ -8399,7 +8399,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v30)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -8592,16 +8592,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                       coe
                                                                                                                                                                         (case coe
                                                                                                                                                                                 v37 of
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v38
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v38
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                   (coe
                                                                                                                                                                                      C_cse_14
                                                                                                                                                                                      v36
                                                                                                                                                                                      v38)
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v41 v42 v43
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v41 v42 v43
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                   v41
                                                                                                                                                                                   v42
                                                                                                                                                                                   v43
@@ -8612,7 +8612,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                  (coe
                                                                                                                                                                     v35)
                                                                                                                                                                  (coe
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                                     v1
                                                                                                                                                                     v2)
@@ -8653,16 +8653,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                          coe
                                                                                                                                                            (case coe
                                                                                                                                                                    v32 of
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                      (coe
                                                                                                                                                                         C_cse_14
                                                                                                                                                                         v31
                                                                                                                                                                         v33)
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                      v36
                                                                                                                                                                      v37
                                                                                                                                                                      v38
@@ -8673,7 +8673,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     (coe
                                                                                                                                                        v30)
                                                                                                                                                     (coe
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                        v1
                                                                                                                                                        v2)
@@ -8864,16 +8864,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v32 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v31
                                                                                                                                                                    v33)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v36
                                                                                                                                                                 v37
                                                                                                                                                                 v38
@@ -8884,7 +8884,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v30)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -9077,16 +9077,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                       coe
                                                                                                                                                                         (case coe
                                                                                                                                                                                 v37 of
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v38
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v38
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                   (coe
                                                                                                                                                                                      C_cse_14
                                                                                                                                                                                      v36
                                                                                                                                                                                      v38)
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v41 v42 v43
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v41 v42 v43
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                   v41
                                                                                                                                                                                   v42
                                                                                                                                                                                   v43
@@ -9097,7 +9097,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                  (coe
                                                                                                                                                                     v35)
                                                                                                                                                                  (coe
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                                     v1
                                                                                                                                                                     v2)
@@ -9138,16 +9138,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                          coe
                                                                                                                                                            (case coe
                                                                                                                                                                    v32 of
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                      (coe
                                                                                                                                                                         C_cse_14
                                                                                                                                                                         v31
                                                                                                                                                                         v33)
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                      v36
                                                                                                                                                                      v37
                                                                                                                                                                      v38
@@ -9158,7 +9158,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     (coe
                                                                                                                                                        v30)
                                                                                                                                                     (coe
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                        v1
                                                                                                                                                        v2)
@@ -9349,16 +9349,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v33 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v32
                                                                                                                                                                    v34)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v37
                                                                                                                                                                 v38
                                                                                                                                                                 v39
@@ -9369,7 +9369,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v31)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -9562,16 +9562,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                       coe
                                                                                                                                                                         (case coe
                                                                                                                                                                                 v38 of
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v39
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v39
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                   (coe
                                                                                                                                                                                      C_cse_14
                                                                                                                                                                                      v37
                                                                                                                                                                                      v39)
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v42 v43 v44
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v42 v43 v44
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                   v42
                                                                                                                                                                                   v43
                                                                                                                                                                                   v44
@@ -9582,7 +9582,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                  (coe
                                                                                                                                                                     v36)
                                                                                                                                                                  (coe
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                                     v1
                                                                                                                                                                     v2)
@@ -9623,16 +9623,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                          coe
                                                                                                                                                            (case coe
                                                                                                                                                                    v33 of
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                      (coe
                                                                                                                                                                         C_cse_14
                                                                                                                                                                         v32
                                                                                                                                                                         v34)
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                      v37
                                                                                                                                                                      v38
                                                                                                                                                                      v39
@@ -9643,7 +9643,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     (coe
                                                                                                                                                        v31)
                                                                                                                                                     (coe
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                        v1
                                                                                                                                                        v2)
@@ -9834,16 +9834,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v33 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v32
                                                                                                                                                                    v34)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v37
                                                                                                                                                                 v38
                                                                                                                                                                 v39
@@ -9854,7 +9854,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v31)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -10047,16 +10047,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                       coe
                                                                                                                                                                         (case coe
                                                                                                                                                                                 v38 of
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v39
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v39
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                   (coe
                                                                                                                                                                                      C_cse_14
                                                                                                                                                                                      v37
                                                                                                                                                                                      v39)
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v42 v43 v44
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v42 v43 v44
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                   v42
                                                                                                                                                                                   v43
                                                                                                                                                                                   v44
@@ -10067,7 +10067,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                  (coe
                                                                                                                                                                     v36)
                                                                                                                                                                  (coe
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                                     v1
                                                                                                                                                                     v2)
@@ -10108,16 +10108,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                          coe
                                                                                                                                                            (case coe
                                                                                                                                                                    v33 of
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                      (coe
                                                                                                                                                                         C_cse_14
                                                                                                                                                                         v32
                                                                                                                                                                         v34)
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                      v37
                                                                                                                                                                      v38
                                                                                                                                                                      v39
@@ -10128,7 +10128,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     (coe
                                                                                                                                                        v31)
                                                                                                                                                     (coe
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                        v1
                                                                                                                                                        v2)
@@ -10319,16 +10319,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v32 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v31
                                                                                                                                                                    v33)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v36
                                                                                                                                                                 v37
                                                                                                                                                                 v38
@@ -10339,7 +10339,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v30)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -10532,16 +10532,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                       coe
                                                                                                                                                                         (case coe
                                                                                                                                                                                 v37 of
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v38
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v38
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                   (coe
                                                                                                                                                                                      C_cse_14
                                                                                                                                                                                      v36
                                                                                                                                                                                      v38)
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v41 v42 v43
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v41 v42 v43
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                   v41
                                                                                                                                                                                   v42
                                                                                                                                                                                   v43
@@ -10552,7 +10552,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                  (coe
                                                                                                                                                                     v35)
                                                                                                                                                                  (coe
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                                     v1
                                                                                                                                                                     v2)
@@ -10593,16 +10593,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                          coe
                                                                                                                                                            (case coe
                                                                                                                                                                    v32 of
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                      (coe
                                                                                                                                                                         C_cse_14
                                                                                                                                                                         v31
                                                                                                                                                                         v33)
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                      v36
                                                                                                                                                                      v37
                                                                                                                                                                      v38
@@ -10613,7 +10613,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     (coe
                                                                                                                                                        v30)
                                                                                                                                                     (coe
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                        v1
                                                                                                                                                        v2)
@@ -10804,16 +10804,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     coe
                                                                                                                                                       (case coe
                                                                                                                                                               v31 of
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v32
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v32
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                 (coe
                                                                                                                                                                    C_cse_14
                                                                                                                                                                    v30
                                                                                                                                                                    v32)
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v35 v36 v37
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v35 v36 v37
                                                                                                                                                            -> coe
-                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                 v35
                                                                                                                                                                 v36
                                                                                                                                                                 v37
@@ -10824,7 +10824,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                (coe
                                                                                                                                                   v29)
                                                                                                                                                (coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                   v1
                                                                                                                                                   v2)
@@ -11017,16 +11017,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                       coe
                                                                                                                                                                         (case coe
                                                                                                                                                                                 v36 of
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v37
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v37
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                   (coe
                                                                                                                                                                                      C_cse_14
                                                                                                                                                                                      v35
                                                                                                                                                                                      v37)
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v40 v41 v42
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v40 v41 v42
                                                                                                                                                                              -> coe
-                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                   v40
                                                                                                                                                                                   v41
                                                                                                                                                                                   v42
@@ -11037,7 +11037,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                  (coe
                                                                                                                                                                     v34)
                                                                                                                                                                  (coe
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                                     v1
                                                                                                                                                                     v2)
@@ -11078,16 +11078,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                          coe
                                                                                                                                                            (case coe
                                                                                                                                                                    v31 of
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v32
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v32
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                      (coe
                                                                                                                                                                         C_cse_14
                                                                                                                                                                         v30
                                                                                                                                                                         v32)
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v35 v36 v37
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v35 v36 v37
                                                                                                                                                                 -> coe
-                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                      v35
                                                                                                                                                                      v36
                                                                                                                                                                      v37
@@ -11098,7 +11098,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                     (coe
                                                                                                                                                        v29)
                                                                                                                                                     (coe
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                        v1
                                                                                                                                                        v2)
@@ -11190,16 +11190,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                       coe
                                                                                                                                         (case coe
                                                                                                                                                 v28 of
-                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v29
+                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v29
                                                                                                                                              -> coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                   (coe
                                                                                                                                                      C_cse_14
                                                                                                                                                      v27
                                                                                                                                                      v29)
-                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v32 v33 v34
+                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v32 v33 v34
                                                                                                                                              -> coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   v32
                                                                                                                                                   v33
                                                                                                                                                   v34
@@ -11210,7 +11210,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                  (coe
                                                                                                                                     v26)
                                                                                                                                  (coe
-                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                     v1
                                                                                                                                     v2)
@@ -11309,16 +11309,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                coe
                                                                                                                                                                  (case coe
                                                                                                                                                                          v33 of
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                                                                       -> coe
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                            (coe
                                                                                                                                                                               C_cse_14
                                                                                                                                                                               v32
                                                                                                                                                                               v34)
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                                                                       -> coe
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                            v37
                                                                                                                                                                            v38
                                                                                                                                                                            v39
@@ -11329,7 +11329,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                           (coe
                                                                                                                                                              v31)
                                                                                                                                                           (coe
-                                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                              v1
                                                                                                                                                              v2)
@@ -11370,16 +11370,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                   coe
                                                                                                                                                     (case coe
                                                                                                                                                             v30 of
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v31
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v31
                                                                                                                                                          -> coe
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                               (coe
                                                                                                                                                                  C_cse_14
                                                                                                                                                                  v29
                                                                                                                                                                  v31)
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v34 v35 v36
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v34 v35 v36
                                                                                                                                                          -> coe
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                               v34
                                                                                                                                                               v35
                                                                                                                                                               v36
@@ -11390,7 +11390,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                              (coe
                                                                                                                                                 v28)
                                                                                                                                              (coe
-                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                 v1
                                                                                                                                                 v2)
@@ -11401,14 +11401,14 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                    -> coe
                                                                                         seq (coe v9)
                                                                                         (coe
-                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                            v1 v2)
                                                                                  MAlonzo.Code.Untyped.C_con_28 v19
                                                                                    -> coe
                                                                                         seq (coe v9)
                                                                                         (coe
-                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                            v1 v2)
                                                                                  MAlonzo.Code.Untyped.C_constr_34 v19 v20
@@ -11502,16 +11502,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                              coe
                                                                                                                                                (case coe
                                                                                                                                                        v31 of
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v32
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v32
                                                                                                                                                     -> coe
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                          (coe
                                                                                                                                                             C_cse_14
                                                                                                                                                             v30
                                                                                                                                                             v32)
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v35 v36 v37
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v35 v36 v37
                                                                                                                                                     -> coe
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                          v35
                                                                                                                                                          v36
                                                                                                                                                          v37
@@ -11522,7 +11522,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                         (coe
                                                                                                                                            v29)
                                                                                                                                         (coe
-                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                            v1
                                                                                                                                            v2)
@@ -11622,16 +11622,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                coe
                                                                                                                                                                  (case coe
                                                                                                                                                                          v36 of
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v37
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v37
                                                                                                                                                                       -> coe
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                            (coe
                                                                                                                                                                               C_cse_14
                                                                                                                                                                               v35
                                                                                                                                                                               v37)
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v40 v41 v42
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v40 v41 v42
                                                                                                                                                                       -> coe
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                            v40
                                                                                                                                                                            v41
                                                                                                                                                                            v42
@@ -11642,7 +11642,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                           (coe
                                                                                                                                                              v34)
                                                                                                                                                           (coe
-                                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                              v1
                                                                                                                                                              v2)
@@ -11683,16 +11683,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                   coe
                                                                                                                                                     (case coe
                                                                                                                                                             v31 of
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v32
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v32
                                                                                                                                                          -> coe
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                               (coe
                                                                                                                                                                  C_cse_14
                                                                                                                                                                  v30
                                                                                                                                                                  v32)
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v35 v36 v37
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v35 v36 v37
                                                                                                                                                          -> coe
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                               v35
                                                                                                                                                               v36
                                                                                                                                                               v37
@@ -11703,7 +11703,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                              (coe
                                                                                                                                                 v29)
                                                                                                                                              (coe
-                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                 v1
                                                                                                                                                 v2)
@@ -11801,16 +11801,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                              coe
                                                                                                                                                (case coe
                                                                                                                                                        v31 of
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v32
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v32
                                                                                                                                                     -> coe
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                          (coe
                                                                                                                                                             C_cse_14
                                                                                                                                                             v30
                                                                                                                                                             v32)
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v35 v36 v37
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v35 v36 v37
                                                                                                                                                     -> coe
-                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                          v35
                                                                                                                                                          v36
                                                                                                                                                          v37
@@ -11821,7 +11821,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                         (coe
                                                                                                                                            v29)
                                                                                                                                         (coe
-                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                            v1
                                                                                                                                            v2)
@@ -11921,16 +11921,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                                coe
                                                                                                                                                                  (case coe
                                                                                                                                                                          v36 of
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v37
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v37
                                                                                                                                                                       -> coe
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                            (coe
                                                                                                                                                                               C_cse_14
                                                                                                                                                                               v35
                                                                                                                                                                               v37)
-                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v40 v41 v42
+                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v40 v41 v42
                                                                                                                                                                       -> coe
-                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                            v40
                                                                                                                                                                            v41
                                                                                                                                                                            v42
@@ -11941,7 +11941,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                           (coe
                                                                                                                                                              v34)
                                                                                                                                                           (coe
-                                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                              v1
                                                                                                                                                              v2)
@@ -11982,16 +11982,16 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                                   coe
                                                                                                                                                     (case coe
                                                                                                                                                             v31 of
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v32
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v32
                                                                                                                                                          -> coe
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                               (coe
                                                                                                                                                                  C_cse_14
                                                                                                                                                                  v30
                                                                                                                                                                  v32)
-                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v35 v36 v37
+                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v35 v36 v37
                                                                                                                                                          -> coe
-                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                               v35
                                                                                                                                                               v36
                                                                                                                                                               v37
@@ -12002,7 +12002,7 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                                                                              (coe
                                                                                                                                                 v29)
                                                                                                                                              (coe
-                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                                                                                 v1
                                                                                                                                                 v2)
@@ -12013,14 +12013,14 @@ d_isUCSE'63'_24 v0 v1 v2
                                                                                    -> coe
                                                                                         seq (coe v9)
                                                                                         (coe
-                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                            v1 v2)
                                                                                  MAlonzo.Code.Untyped.C_error_46
                                                                                    -> coe
                                                                                         seq (coe v9)
                                                                                         (coe
-                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                                            v1 v2)
                                                                                  _ -> MAlonzo.RTE.mazUnreachableError))
@@ -12029,71 +12029,71 @@ d_isUCSE'63'_24 v0 v1 v2
                                                       else coe
                                                              seq (coe v13)
                                                              (coe
-                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40
                                                                 v1 v2)
                                                _ -> MAlonzo.RTE.mazUnreachableError))
                              _ -> MAlonzo.RTE.mazUnreachableError)
                    MAlonzo.Code.Untyped.C__'183'__22 v7 v8
                      -> coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
                    MAlonzo.Code.Untyped.C_force_24 v7
                      -> coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
                    MAlonzo.Code.Untyped.C_delay_26 v7
                      -> coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
                    MAlonzo.Code.Untyped.C_con_28 v7
                      -> coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
                    MAlonzo.Code.Untyped.C_constr_34 v7 v8
                      -> coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
                    MAlonzo.Code.Untyped.C_case_40 v7 v8
                      -> coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
                    MAlonzo.Code.Untyped.C_builtin_44 v7
                      -> coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
                    MAlonzo.Code.Untyped.C_error_46
                      -> coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
                    _ -> MAlonzo.RTE.mazUnreachableError
             MAlonzo.Code.Untyped.C_force_24 v5
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
             MAlonzo.Code.Untyped.C_delay_26 v5
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
             MAlonzo.Code.Untyped.C_con_28 v5
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
             MAlonzo.Code.Untyped.C_constr_34 v5 v6
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
             MAlonzo.Code.Untyped.C_case_40 v5 v6
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
             MAlonzo.Code.Untyped.C_builtin_44 v5
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
             MAlonzo.Code.Untyped.C_error_46
               -> coe
-                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                    MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_40 v1 v2
             _ -> MAlonzo.RTE.mazUnreachableError))
 -- VerifiedCompilation.UCSE..extendedlambda0

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCaseOfCase.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCaseOfCase.hs
@@ -555,7 +555,7 @@ d_isCaseOfCase'63'_256 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_isCaseOfCase'63'_256 v0
   = coe
       MAlonzo.Code.VerifiedCompilation.UntypedTranslation.du_translation'63'_160
@@ -567,7 +567,7 @@ d_isCoC'63'_264 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_isCoC'63'_264 v0 v1 v2
   = let v3
           = coe
@@ -669,7 +669,7 @@ d_isCoC'63'_264 v0 v1 v2
                                                                                                                                                                                              v43)
                                                                                                                                                                                           (let v44
                                                                                                                                                                                                  = coe
-                                                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.du_pcePointwise_304
+                                                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.du_pcePointwise_316
                                                                                                                                                                                                      (coe
                                                                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_48)
                                                                                                                                                                                                      (coe
@@ -683,10 +683,10 @@ d_isCoC'63'_264 v0 v1 v2
                                                                                                                                                                                            coe
                                                                                                                                                                                              (case coe
                                                                                                                                                                                                      v44 of
-                                                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v45
+                                                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v45
                                                                                                                                                                                                   -> let v46
                                                                                                                                                                                                            = coe
-                                                                                                                                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.du_pcePointwise_304
+                                                                                                                                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.du_pcePointwise_316
                                                                                                                                                                                                                (coe
                                                                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_48)
                                                                                                                                                                                                                (coe
@@ -700,10 +700,10 @@ d_isCoC'63'_264 v0 v1 v2
                                                                                                                                                                                                      coe
                                                                                                                                                                                                        (case coe
                                                                                                                                                                                                                v46 of
-                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v47
+                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v47
                                                                                                                                                                                                             -> let v48
                                                                                                                                                                                                                      = coe
-                                                                                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.du_pcePointwise_304
+                                                                                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.du_pcePointwise_316
                                                                                                                                                                                                                          (coe
                                                                                                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_48)
                                                                                                                                                                                                                          (coe
@@ -717,31 +717,31 @@ d_isCoC'63'_264 v0 v1 v2
                                                                                                                                                                                                                coe
                                                                                                                                                                                                                  (case coe
                                                                                                                                                                                                                          v48 of
-                                                                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v49
+                                                                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v49
                                                                                                                                                                                                                       -> coe
-                                                                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                                                            (coe
                                                                                                                                                                                                                               C_isCoC_26
                                                                                                                                                                                                                               v49
                                                                                                                                                                                                                               v45
                                                                                                                                                                                                                               v47)
-                                                                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v52 v53 v54
+                                                                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v52 v53 v54
                                                                                                                                                                                                                       -> coe
-                                                                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                            v52
                                                                                                                                                                                                                            v53
                                                                                                                                                                                                                            v54
                                                                                                                                                                                                                     _ -> MAlonzo.RTE.mazUnreachableError)
-                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v50 v51 v52
+                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v50 v51 v52
                                                                                                                                                                                                             -> coe
-                                                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                  v50
                                                                                                                                                                                                                  v51
                                                                                                                                                                                                                  v52
                                                                                                                                                                                                           _ -> MAlonzo.RTE.mazUnreachableError)
-                                                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v48 v49 v50
+                                                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v48 v49 v50
                                                                                                                                                                                                   -> coe
-                                                                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                        v48
                                                                                                                                                                                                        v49
                                                                                                                                                                                                        v50
@@ -753,7 +753,7 @@ d_isCoC'63'_264 v0 v1 v2
                                                                                                                                                                             (coe
                                                                                                                                                                                v40)
                                                                                                                                                                             (coe
-                                                                                                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_48
                                                                                                                                                                                (coe
                                                                                                                                                                                   MAlonzo.Code.Untyped.C_case_40
@@ -825,7 +825,7 @@ d_isCoC'63'_264 v0 v1 v2
                 else coe
                        seq (coe v5)
                        (coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_48 v1 v2)
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- VerifiedCompilation.UCaseOfCase..extendedlambda4

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCaseReduce.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCaseReduce.hs
@@ -1897,7 +1897,7 @@ d_decide_526 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_decide_526 v0 v1 v2
   = let v3
           = MAlonzo.Code.Untyped.Equality.d_decEq'45''8866'_56
@@ -2492,12 +2492,12 @@ d_decide_526 v0 v1 v2
                 then case coe v5 of
                        MAlonzo.Code.Relation.Nullary.Reflects.C_of'696'_22 v6
                          -> coe
-                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 (coe v6)
+                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 (coe v6)
                        _ -> MAlonzo.RTE.mazUnreachableError
                 else coe
                        seq (coe v5)
                        (coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_CaseReduceT_46 v1 v2)
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- VerifiedCompilation.UCaseReduce.case-reduce-refines
@@ -2926,14 +2926,14 @@ d_decide'45''126'_648 ::
    MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12) ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_decide'45''126'_648 v0 ~v1 v2 v3
   = du_decide'45''126'_648 v0 v2 v3
 du_decide'45''126'_648 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 du_decide'45''126'_648 v0 v1 v2
   = let v3
           = MAlonzo.Code.Untyped.Equality.d_decEq'45''8866'_56
@@ -3528,11 +3528,11 @@ du_decide'45''126'_648 v0 v1 v2
                 then coe
                        seq (coe v5)
                        (coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                           (coe du_sound'45'both_640 (coe v0) (coe v1) (coe v2)))
                 else coe
                        seq (coe v5)
                        (coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_CaseReduceT_46 v1 v2)
          _ -> MAlonzo.RTE.mazUnreachableError)

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UFloatDelay.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UFloatDelay.hs
@@ -113,7 +113,7 @@ d_isFloatDelay'63'_102 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_isFloatDelay'63'_102 v0
   = coe
       MAlonzo.Code.VerifiedCompilation.UntypedTranslation.du_translation'63'_160
@@ -125,7 +125,7 @@ d_isFlD'63'_106 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_isFlD'63'_106 v0 v1 v2
   = let v3
           = coe
@@ -234,7 +234,7 @@ d_isFlD'63'_106 v0 v1 v2
                                                                                                                                       coe
                                                                                                                                         (case coe
                                                                                                                                                 v32 of
-                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                              -> let v34
                                                                                                                                                       = coe
                                                                                                                                                           d_isFloatDelay'63'_102
@@ -244,7 +244,7 @@ d_isFlD'63'_106 v0 v1 v2
                                                                                                                                                 coe
                                                                                                                                                   (case coe
                                                                                                                                                           v34 of
-                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v35
+                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v35
                                                                                                                                                        -> let v36
                                                                                                                                                                 = MAlonzo.Code.Untyped.Purity.d_isPure'63'_72
                                                                                                                                                                     (coe
@@ -261,7 +261,7 @@ d_isFlD'63'_106 v0 v1 v2
                                                                                                                                                                                   v38 of
                                                                                                                                                                              MAlonzo.Code.Relation.Nullary.Reflects.C_of'696'_22 v39
                                                                                                                                                                                -> coe
-                                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                     (coe
                                                                                                                                                                                        C_floatdelay_90
                                                                                                                                                                                        v33
@@ -273,21 +273,21 @@ d_isFlD'63'_106 v0 v1 v2
                                                                                                                                                                              (coe
                                                                                                                                                                                 v38)
                                                                                                                                                                              (coe
-                                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_FloatDelayT_32
                                                                                                                                                                                 v1
                                                                                                                                                                                 v2)
                                                                                                                                                                _ -> MAlonzo.RTE.mazUnreachableError)
-                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v38 v39 v40
+                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v38 v39 v40
                                                                                                                                                        -> coe
-                                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                             v38
                                                                                                                                                             v39
                                                                                                                                                             v40
                                                                                                                                                      _ -> MAlonzo.RTE.mazUnreachableError)
-                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                              -> coe
-                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                   v36
                                                                                                                                                   v37
                                                                                                                                                   v38
@@ -302,7 +302,7 @@ d_isFlD'63'_106 v0 v1 v2
                                                                                                (coe
                                                                                                   v21)
                                                                                                (coe
-                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_FloatDelayT_32
                                                                                                   v1
                                                                                                   v2)
@@ -317,7 +317,7 @@ d_isFlD'63'_106 v0 v1 v2
                 else coe
                        seq (coe v5)
                        (coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_FloatDelayT_32 v1 v2)
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- VerifiedCompilation.UFloatDelay..extendedlambda0

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UForceCaseDelay.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UForceCaseDelay.hs
@@ -162,7 +162,7 @@ d_isForceCaseDelay'63'_94 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_isForceCaseDelay'63'_94 v0
   = coe
       MAlonzo.Code.VerifiedCompilation.UntypedTranslation.du_translation'63'_160
@@ -174,7 +174,7 @@ d_isFCD'63'_96 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_isFCD'63'_96 v0 v1 v2
   = let v3
           = coe
@@ -266,10 +266,10 @@ d_isFCD'63'_96 v0 v1 v2
                                                                                                                                   coe
                                                                                                                                     (case coe
                                                                                                                                             v30 of
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v31
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v31
                                                                                                                                          -> let v32
                                                                                                                                                   = coe
-                                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.du_pcePointwise_304
+                                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.du_pcePointwise_316
                                                                                                                                                       (coe
                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_ForceCaseDelayT_36)
                                                                                                                                                       (coe
@@ -287,24 +287,24 @@ d_isFCD'63'_96 v0 v1 v2
                                                                                                                                             coe
                                                                                                                                               (case coe
                                                                                                                                                       v32 of
-                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                                    -> coe
-                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                         (coe
                                                                                                                                                            C_isFCD_86
                                                                                                                                                            v29
                                                                                                                                                            v31
                                                                                                                                                            v33)
-                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                                    -> coe
-                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                         MAlonzo.Code.VerifiedCompilation.Trace.d_ForceCaseDelayT_36
                                                                                                                                                         v1
                                                                                                                                                         v2
                                                                                                                                                  _ -> MAlonzo.RTE.mazUnreachableError)
-                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v34 v35 v36
+                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v34 v35 v36
                                                                                                                                          -> coe
-                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                               MAlonzo.Code.VerifiedCompilation.Trace.d_ForceCaseDelayT_36
                                                                                                                                               v1
                                                                                                                                               v2
@@ -315,7 +315,7 @@ d_isFCD'63'_96 v0 v1 v2
                                                                                                                              (coe
                                                                                                                                 v28)
                                                                                                                              (coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_ForceCaseDelayT_36
                                                                                                                                 v1
                                                                                                                                 v2)
@@ -326,7 +326,7 @@ d_isFCD'63'_96 v0 v1 v2
                                                                           else coe
                                                                                  seq (coe v18)
                                                                                  (coe
-                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_ForceCaseDelayT_36
                                                                                     v1 v2)
                                                                    _ -> MAlonzo.RTE.mazUnreachableError)))
@@ -338,7 +338,7 @@ d_isFCD'63'_96 v0 v1 v2
                 else coe
                        seq (coe v5)
                        (coe
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                           MAlonzo.Code.VerifiedCompilation.Trace.d_ForceCaseDelayT_36 v1 v2)
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- VerifiedCompilation.UForceCaseDelay..extendedlambda1

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UForceDelay.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UForceDelay.hs
@@ -578,7 +578,7 @@ d_isForceDelay'63'_178 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_isForceDelay'63'_178 v0
   = coe
       MAlonzo.Code.VerifiedCompilation.UntypedTranslation.du_translation'63'_160
@@ -591,7 +591,7 @@ d_isFD'63'_184 ::
   T_Zipper_78 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_isFD'63'_184 v0 v1 v2 v3
   = case coe v1 of
       C_'9633'_82
@@ -621,13 +621,13 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                               (coe v10) (coe v3) in
                                                     coe
                                                       (case coe v11 of
-                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v12
+                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v12
                                                            -> coe
-                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                 (coe C_force_116 v12)
-                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v15 v16 v17
+                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v15 v16 v17
                                                            -> coe
-                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                 v15 v16 v17
                                                          _ -> MAlonzo.RTE.mazUnreachableError))
                                             _ -> MAlonzo.RTE.mazUnreachableError
@@ -710,26 +710,26 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                              coe
                                                                                                                (case coe
                                                                                                                        v26 of
-                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v28
+                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v28
                                                                                                                     -> case coe
                                                                                                                               v27 of
-                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v29
+                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v29
                                                                                                                            -> coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                 (coe
                                                                                                                                    C_app_120
                                                                                                                                    v28
                                                                                                                                    v29)
-                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v32 v33 v34
+                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v32 v33 v34
                                                                                                                            -> coe
-                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                 v32
                                                                                                                                 v33
                                                                                                                                 v34
                                                                                                                          _ -> MAlonzo.RTE.mazUnreachableError
-                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v31 v32 v33
+                                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v31 v32 v33
                                                                                                                     -> coe
-                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                          v31
                                                                                                                          v32
                                                                                                                          v33
@@ -744,7 +744,7 @@ d_isFD'63'_184 v0 v1 v2 v3
                                            else coe
                                                   seq (coe v9)
                                                   (coe
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                      MAlonzo.Code.VerifiedCompilation.Trace.d_ForceDelayT_34
                                                      v2 v3)
                                     _ -> MAlonzo.RTE.mazUnreachableError))
@@ -821,17 +821,17 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                          coe
                                                                                            (case coe
                                                                                                    v24 of
-                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v26
+                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v26
                                                                                                 -> case coe
                                                                                                           v25 of
-                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v27
+                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v27
                                                                                                        -> coe
-                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                             (coe
                                                                                                                C_app_120
                                                                                                                v26
                                                                                                                v27)
-                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v30 v31 v32
+                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v30 v31 v32
                                                                                                        -> let v33
                                                                                                                 = d_isFD'63'_184
                                                                                                                     (coe
@@ -845,21 +845,21 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                           coe
                                                                                                             (case coe
                                                                                                                     v33 of
-                                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                  -> coe
-                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                       v30
                                                                                                                       v31
                                                                                                                       v32
-                                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                  -> coe
-                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                       v37
                                                                                                                       v38
                                                                                                                       v39
                                                                                                                _ -> MAlonzo.RTE.mazUnreachableError)
                                                                                                      _ -> MAlonzo.RTE.mazUnreachableError
-                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v29 v30 v31
+                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v29 v30 v31
                                                                                                 -> let v32
                                                                                                          = coe
                                                                                                              MAlonzo.Code.Relation.Nullary.Decidable.Core.du__'215''45'dec__84
@@ -1063,13 +1063,13 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                                                                                                                                                               MAlonzo.Code.Relation.Nullary.Reflects.C_of'696'_22 v81
                                                                                                                                                                                                                                                                                                                 -> case coe
                                                                                                                                                                                                                                                                                                                           v73 of
-                                                                                                                                                                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v82
+                                                                                                                                                                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v82
                                                                                                                                                                                                                                                                                                                        -> case coe
                                                                                                                                                                                                                                                                                                                                  v74 of
-                                                                                                                                                                                                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v83
+                                                                                                                                                                                                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v83
                                                                                                                                                                                                                                                                                                                               -> case coe
                                                                                                                                                                                                                                                                                                                                         v75 of
-                                                                                                                                                                                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v84
+                                                                                                                                                                                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v84
                                                                                                                                                                                                                                                                                                                                      -> let v85
                                                                                                                                                                                                                                                                                                                                               = coe
                                                                                                                                                                                                                                                                                                                                                   MAlonzo.Code.Relation.Nullary.Decidable.Core.du__'215''45'dec__84
@@ -1099,7 +1099,7 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                                                                                                                                                                                                                   (coe
                                                                                                                                                                                                                                                                                                                                                                      v88)
                                                                                                                                                                                                                                                                                                                                                                   (coe
-                                                                                                                                                                                                                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                                                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                                                                                                                                                                                                      (coe
                                                                                                                                                                                                                                                                                                                                                                         C_ifThenElse_128
                                                                                                                                                                                                                                                                                                                                                                         v78
@@ -1113,28 +1113,28 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                                                                                                                                                                                                            (coe
                                                                                                                                                                                                                                                                                                                                                               v87)
                                                                                                                                                                                                                                                                                                                                                            (coe
-                                                                                                                                                                                                                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                                                                                                                                                               MAlonzo.Code.VerifiedCompilation.Trace.d_ForceDelayT_34
                                                                                                                                                                                                                                                                                                                                                               v2
                                                                                                                                                                                                                                                                                                                                                               v3)
                                                                                                                                                                                                                                                                                                                                              _ -> MAlonzo.RTE.mazUnreachableError)
-                                                                                                                                                                                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v87 v88 v89
+                                                                                                                                                                                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v87 v88 v89
                                                                                                                                                                                                                                                                                                                                      -> coe
-                                                                                                                                                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                                                                                                                                           v87
                                                                                                                                                                                                                                                                                                                                           v88
                                                                                                                                                                                                                                                                                                                                           v89
                                                                                                                                                                                                                                                                                                                                    _ -> MAlonzo.RTE.mazUnreachableError
-                                                                                                                                                                                                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v86 v87 v88
+                                                                                                                                                                                                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v86 v87 v88
                                                                                                                                                                                                                                                                                                                               -> coe
-                                                                                                                                                                                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                                                                                                                                    v86
                                                                                                                                                                                                                                                                                                                                    v87
                                                                                                                                                                                                                                                                                                                                    v88
                                                                                                                                                                                                                                                                                                                             _ -> MAlonzo.RTE.mazUnreachableError
-                                                                                                                                                                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v85 v86 v87
+                                                                                                                                                                                                                                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v85 v86 v87
                                                                                                                                                                                                                                                                                                                        -> coe
-                                                                                                                                                                                                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                                                                                                                             v85
                                                                                                                                                                                                                                                                                                                             v86
                                                                                                                                                                                                                                                                                                                             v87
@@ -1145,7 +1145,7 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                                                                                                                                                               (coe
                                                                                                                                                                                                                                                                                                                  v80)
                                                                                                                                                                                                                                                                                                               (coe
-                                                                                                                                                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Trace.d_ForceDelayT_34
                                                                                                                                                                                                                                                                                                                  v16
                                                                                                                                                                                                                                                                                                                  v22)
@@ -1156,7 +1156,7 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                                                                                                                                          (coe
                                                                                                                                                                                                                                                                                             v77)
                                                                                                                                                                                                                                                                                          (coe
-                                                                                                                                                                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Trace.d_ForceDelayT_34
                                                                                                                                                                                                                                                                                             v43
                                                                                                                                                                                                                                                                                             v59)
@@ -1183,7 +1183,7 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                       (coe
                                                                                                                          v34)
                                                                                                                       (coe
-                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                          v29
                                                                                                                          v30
                                                                                                                          v31)
@@ -1225,13 +1225,13 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                   (coe v3) in
                                                                         coe
                                                                           (case coe v15 of
-                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v16
+                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v16
                                                                                -> coe
-                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                     (coe
                                                                                        C_delay_118
                                                                                        v16)
-                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v19 v20 v21
+                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v19 v20 v21
                                                                                -> case coe v4 of
                                                                                     C_'9633'_82
                                                                                       -> let v22
@@ -1243,27 +1243,27 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                          coe
                                                                                            (case coe
                                                                                                    v22 of
-                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v23
+                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v23
                                                                                                 -> coe
-                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                      (coe
                                                                                                         C_last'45'delay_124
                                                                                                         v23)
-                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v26 v27 v28
+                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v26 v27 v28
                                                                                                 -> coe
-                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                      v26
                                                                                                      v27
                                                                                                      v28
                                                                                               _ -> MAlonzo.RTE.mazUnreachableError)
                                                                                     C_force_84 v22
                                                                                       -> coe
-                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                            v19 v20
                                                                                            v21
                                                                                     C__'183'__86 v22 v23
                                                                                       -> coe
-                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                            v19 v20
                                                                                            v21
                                                                                     _ -> MAlonzo.RTE.mazUnreachableError
@@ -1309,15 +1309,15 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                             coe
                                                                                               (case coe
                                                                                                       v18 of
-                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v19
+                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v19
                                                                                                    -> coe
-                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                         (coe
                                                                                                            C_force_116
                                                                                                            v19)
-                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v22 v23 v24
+                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v22 v23 v24
                                                                                                    -> coe
-                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                         v22
                                                                                                         v23
                                                                                                         v24
@@ -1328,7 +1328,7 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                else coe
                                                                       seq (coe v13)
                                                                       (coe
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_ForceDelayT_34
                                                                          v2 v3)
                                                         _ -> MAlonzo.RTE.mazUnreachableError))
@@ -1388,13 +1388,13 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                       (coe v17) in
                                                                             coe
                                                                               (case coe v18 of
-                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v19
+                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v19
                                                                                    -> coe
-                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                         (coe
                                                                                            C_abs_122
                                                                                            v19)
-                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v22 v23 v24
+                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v22 v23 v24
                                                                                    -> case coe v4 of
                                                                                         C_'9633'_82
                                                                                           -> let v25
@@ -1411,28 +1411,28 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                              coe
                                                                                                (case coe
                                                                                                        v25 of
-                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v26
+                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v26
                                                                                                     -> coe
-                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                          (coe
                                                                                                             C_last'45'abs_126
                                                                                                             v26)
-                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v29 v30 v31
+                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v29 v30 v31
                                                                                                     -> coe
-                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                          v29
                                                                                                          v30
                                                                                                          v31
                                                                                                   _ -> MAlonzo.RTE.mazUnreachableError)
                                                                                         C_force_84 v25
                                                                                           -> coe
-                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                v22
                                                                                                v23
                                                                                                v24
                                                                                         C__'183'__86 v25 v26
                                                                                           -> coe
-                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                v22
                                                                                                v23
                                                                                                v24
@@ -1552,17 +1552,17 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                               coe
                                                                                                                                                                 (case coe
                                                                                                                                                                         v35 of
-                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v37
+                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v37
                                                                                                                                                                      -> case coe
                                                                                                                                                                                v36 of
-                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v38
+                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v38
                                                                                                                                                                             -> coe
-                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                  (coe
                                                                                                                                                                                     C_app_120
                                                                                                                                                                                     v37
                                                                                                                                                                                     v38)
-                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v41 v42 v43
+                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v41 v42 v43
                                                                                                                                                                             -> let v44
                                                                                                                                                                                      = d_isFD'63'_184
                                                                                                                                                                                          (coe
@@ -1578,21 +1578,21 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                                coe
                                                                                                                                                                                  (case coe
                                                                                                                                                                                          v44 of
-                                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v45
+                                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v45
                                                                                                                                                                                       -> coe
-                                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                            v41
                                                                                                                                                                                            v42
                                                                                                                                                                                            v43
-                                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v48 v49 v50
+                                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v48 v49 v50
                                                                                                                                                                                       -> coe
-                                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                            v48
                                                                                                                                                                                            v49
                                                                                                                                                                                            v50
                                                                                                                                                                                     _ -> MAlonzo.RTE.mazUnreachableError)
                                                                                                                                                                           _ -> MAlonzo.RTE.mazUnreachableError
-                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v40 v41 v42
+                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v40 v41 v42
                                                                                                                                                                      -> let v43
                                                                                                                                                                               = coe
                                                                                                                                                                                   MAlonzo.Code.Relation.Nullary.Decidable.Core.du__'215''45'dec__84
@@ -1800,13 +1800,13 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                                                                                                                                                                                                                                    MAlonzo.Code.Relation.Nullary.Reflects.C_of'696'_22 v92
                                                                                                                                                                                                                                                                                                                                                                                      -> case coe
                                                                                                                                                                                                                                                                                                                                                                                                v84 of
-                                                                                                                                                                                                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v93
+                                                                                                                                                                                                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v93
                                                                                                                                                                                                                                                                                                                                                                                             -> case coe
                                                                                                                                                                                                                                                                                                                                                                                                       v85 of
-                                                                                                                                                                                                                                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v94
+                                                                                                                                                                                                                                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v94
                                                                                                                                                                                                                                                                                                                                                                                                    -> case coe
                                                                                                                                                                                                                                                                                                                                                                                                              v86 of
-                                                                                                                                                                                                                                                                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v95
+                                                                                                                                                                                                                                                                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v95
                                                                                                                                                                                                                                                                                                                                                                                                           -> let v96
                                                                                                                                                                                                                                                                                                                                                                                                                    = coe
                                                                                                                                                                                                                                                                                                                                                                                                                        MAlonzo.Code.Relation.Nullary.Decidable.Core.du__'215''45'dec__84
@@ -1836,7 +1836,7 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                                                                                                                                                                                                                                                                                        (coe
                                                                                                                                                                                                                                                                                                                                                                                                                                           v99)
                                                                                                                                                                                                                                                                                                                                                                                                                                        (coe
-                                                                                                                                                                                                                                                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                                                                                                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                                                                                                                                                                                                                                                                                           (coe
                                                                                                                                                                                                                                                                                                                                                                                                                                              C_ifThenElse_128
                                                                                                                                                                                                                                                                                                                                                                                                                                              v89
@@ -1850,28 +1850,28 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                                                                                                                                                                                                                                                                                 (coe
                                                                                                                                                                                                                                                                                                                                                                                                                                    v98)
                                                                                                                                                                                                                                                                                                                                                                                                                                 (coe
-                                                                                                                                                                                                                                                                                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                                                                                                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                                                                                                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Trace.d_ForceDelayT_34
                                                                                                                                                                                                                                                                                                                                                                                                                                    v15
                                                                                                                                                                                                                                                                                                                                                                                                                                    v3)
                                                                                                                                                                                                                                                                                                                                                                                                                   _ -> MAlonzo.RTE.mazUnreachableError)
-                                                                                                                                                                                                                                                                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v98 v99 v100
+                                                                                                                                                                                                                                                                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v98 v99 v100
                                                                                                                                                                                                                                                                                                                                                                                                           -> coe
-                                                                                                                                                                                                                                                                                                                                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                                                                                                                                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                                                                                                                                                                                                                v98
                                                                                                                                                                                                                                                                                                                                                                                                                v99
                                                                                                                                                                                                                                                                                                                                                                                                                v100
                                                                                                                                                                                                                                                                                                                                                                                                         _ -> MAlonzo.RTE.mazUnreachableError
-                                                                                                                                                                                                                                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v97 v98 v99
+                                                                                                                                                                                                                                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v97 v98 v99
                                                                                                                                                                                                                                                                                                                                                                                                    -> coe
-                                                                                                                                                                                                                                                                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                                                                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                                                                                                                                                                                                         v97
                                                                                                                                                                                                                                                                                                                                                                                                         v98
                                                                                                                                                                                                                                                                                                                                                                                                         v99
                                                                                                                                                                                                                                                                                                                                                                                                  _ -> MAlonzo.RTE.mazUnreachableError
-                                                                                                                                                                                                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v96 v97 v98
+                                                                                                                                                                                                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v96 v97 v98
                                                                                                                                                                                                                                                                                                                                                                                             -> coe
-                                                                                                                                                                                                                                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                                                                                                                                                                                                  v96
                                                                                                                                                                                                                                                                                                                                                                                                  v97
                                                                                                                                                                                                                                                                                                                                                                                                  v98
@@ -1882,7 +1882,7 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                                                                                                                                                                                                                                    (coe
                                                                                                                                                                                                                                                                                                                                                                                       v91)
                                                                                                                                                                                                                                                                                                                                                                                    (coe
-                                                                                                                                                                                                                                                                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                                                                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                                                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Trace.d_ForceDelayT_34
                                                                                                                                                                                                                                                                                                                                                                                       v27
                                                                                                                                                                                                                                                                                                                                                                                       v33)
@@ -1893,7 +1893,7 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                                                                                                                                                                                                               (coe
                                                                                                                                                                                                                                                                                                                                                                  v88)
                                                                                                                                                                                                                                                                                                                                                               (coe
-                                                                                                                                                                                                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                                                                                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Trace.d_ForceDelayT_34
                                                                                                                                                                                                                                                                                                                                                                  v54
                                                                                                                                                                                                                                                                                                                                                                  v70)
@@ -1920,7 +1920,7 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                                            (coe
                                                                                                                                                                                               v45)
                                                                                                                                                                                            (coe
-                                                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                                               v40
                                                                                                                                                                                               v41
                                                                                                                                                                                               v42)
@@ -1932,15 +1932,15 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                      coe
                                                                                                                        (case coe
                                                                                                                                v28 of
-                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v29
+                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v29
                                                                                                                             -> coe
-                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                  (coe
                                                                                                                                     C_force_116
                                                                                                                                     v29)
-                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v32 v33 v34
+                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v32 v33 v34
                                                                                                                             -> coe
-                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                  v32
                                                                                                                                  v33
                                                                                                                                  v34
@@ -1996,15 +1996,15 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                               coe
                                                                                                                                                 (case coe
                                                                                                                                                         v26 of
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v27
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v27
                                                                                                                                                      -> coe
-                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                           (coe
                                                                                                                                                              C_delay_118
                                                                                                                                                              v27)
-                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v30 v31 v32
+                                                                                                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v30 v31 v32
                                                                                                                                                      -> coe
-                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                           v30
                                                                                                                                                           v31
                                                                                                                                                           v32
@@ -2063,15 +2063,15 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                                                   coe
                                                                                                                                                                     (case coe
                                                                                                                                                                             v29 of
-                                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v30
+                                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v30
                                                                                                                                                                          -> coe
-                                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                                               (coe
                                                                                                                                                                                  C_force_116
                                                                                                                                                                                  v30)
-                                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v33 v34 v35
+                                                                                                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v33 v34 v35
                                                                                                                                                                          -> coe
-                                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                                               v33
                                                                                                                                                                               v34
                                                                                                                                                                               v35
@@ -2084,7 +2084,7 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                             (coe
                                                                                                                                                v24)
                                                                                                                                             (coe
-                                                                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Trace.d_ForceDelayT_34
                                                                                                                                                v15
                                                                                                                                                v3)
@@ -2093,15 +2093,15 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                           coe
                                                                                             (case coe
                                                                                                     v19 of
-                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v20
+                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v20
                                                                                                  -> coe
-                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                       (coe
                                                                                                          C_force_116
                                                                                                          v20)
-                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v23 v24 v25
+                                                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v23 v24 v25
                                                                                                  -> coe
-                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                       v23
                                                                                                       v24
                                                                                                       v25
@@ -2193,26 +2193,26 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                                                                                  coe
                                                                                                                                    (case coe
                                                                                                                                            v31 of
-                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v33
+                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v33
                                                                                                                                         -> case coe
                                                                                                                                                   v32 of
-                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v34
+                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v34
                                                                                                                                                -> coe
-                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                                                                     (coe
                                                                                                                                                        C_app_120
                                                                                                                                                        v33
                                                                                                                                                        v34)
-                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v37 v38 v39
+                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v37 v38 v39
                                                                                                                                                -> coe
-                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                                     v37
                                                                                                                                                     v38
                                                                                                                                                     v39
                                                                                                                                              _ -> MAlonzo.RTE.mazUnreachableError
-                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v36 v37 v38
+                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v36 v37 v38
                                                                                                                                         -> coe
-                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                                                              v36
                                                                                                                                              v37
                                                                                                                                              v38
@@ -2227,7 +2227,7 @@ d_isFD'63'_184 v0 v1 v2 v3
                                                                else coe
                                                                       seq (coe v14)
                                                                       (coe
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_ForceDelayT_34
                                                                          v2 v3)
                                                         _ -> MAlonzo.RTE.mazUnreachableError))
@@ -2295,7 +2295,7 @@ d_'46'extendedlambda4_348 ::
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   (MAlonzo.Code.VerifiedCompilation.UntypedViews.T_isForce_270 ->
    MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20) ->
   T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
@@ -2371,9 +2371,9 @@ d_'46'extendedlambda8_634 ::
   (MAlonzo.Code.Untyped.Purity.T_Pure_6 ->
    MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20) ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   MAlonzo.Code.Builtin.T_Builtin_2 ->
   MAlonzo.Code.Builtin.T_Builtin_2 ->
   (T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20) ->
@@ -2384,7 +2384,7 @@ d_'46'extendedlambda8_634 ::
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
 d_'46'extendedlambda8_634 = erased
 -- VerifiedCompilation.UForceDelay..extendedlambda9
@@ -2400,9 +2400,9 @@ d_'46'extendedlambda9_688 ::
   MAlonzo.Code.Untyped.Purity.T_Pure_6 ->
   (MAlonzo.Code.Untyped.Purity.T_Pure_6 ->
    MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20) ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   MAlonzo.Code.Builtin.T_Builtin_2 ->
   MAlonzo.Code.Builtin.T_Builtin_2 ->
   (T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20) ->
@@ -2413,7 +2413,7 @@ d_'46'extendedlambda9_688 ::
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
 d_'46'extendedlambda9_688 = erased
 -- VerifiedCompilation.UForceDelay..extendedlambda10
@@ -2437,8 +2437,8 @@ d_'46'extendedlambda10_750 ::
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   MAlonzo.Code.Builtin.T_Builtin_2 ->
   MAlonzo.Code.Builtin.T_Builtin_2 ->
   (T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20) ->
@@ -2449,7 +2449,7 @@ d_'46'extendedlambda10_750 ::
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
 d_'46'extendedlambda10_750 = erased
 -- VerifiedCompilation.UForceDelay..extendedlambda11
@@ -2473,7 +2473,7 @@ d_'46'extendedlambda11_814 ::
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   MAlonzo.Code.Builtin.T_Builtin_2 ->
   MAlonzo.Code.Builtin.T_Builtin_2 ->
   (T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20) ->
@@ -2484,7 +2484,7 @@ d_'46'extendedlambda11_814 ::
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
 d_'46'extendedlambda11_814 = erased
 -- VerifiedCompilation.UForceDelay..extendedlambda12
@@ -2519,7 +2519,7 @@ d_'46'extendedlambda12_880 ::
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
 d_'46'extendedlambda12_880 = erased
 -- VerifiedCompilation.UForceDelay..extendedlambda13
@@ -2549,7 +2549,7 @@ d_'46'extendedlambda13_1034 ::
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
 d_'46'extendedlambda13_1034 = erased
 -- VerifiedCompilation.UForceDelay..extendedlambda14
@@ -2570,7 +2570,7 @@ d_'46'extendedlambda14_1074 ::
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
 d_'46'extendedlambda14_1074 = erased
 -- VerifiedCompilation.UForceDelay..extendedlambda15
@@ -2806,7 +2806,7 @@ d_'46'extendedlambda26_1732 ::
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50 ->
   (MAlonzo.Code.VerifiedCompilation.UntypedViews.T_isForce_270 ->
    MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20) ->
   (MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14 ->

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UInline.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UInline.hs
@@ -303,11 +303,11 @@ d_checkPointwise_304 ::
   T__'8829'__102 ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_Proof'63'_66
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_Proof'63'_78
 d_checkPointwise_304 v0 v1 v2 v3 v4 v5 v6 v7
   = let v8
           = coe
-              MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
+              MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_90
               MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_38 v6 v7 in
     coe
       (case coe v3 of
@@ -317,7 +317,7 @@ d_checkPointwise_304 v0 v1 v2 v3 v4 v5 v6 v7
                   -> case coe v7 of
                        []
                          -> coe
-                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                               (coe
                                  MAlonzo.Code.Data.List.Relation.Binary.Pointwise.Base.C_'91''93'_56)
                        _ -> coe v8
@@ -328,21 +328,21 @@ d_checkPointwise_304 v0 v1 v2 v3 v4 v5 v6 v7
                   -> case coe v7 of
                        (:) v13 v14
                          -> coe
-                              MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                              MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                               (coe
                                  d_check_316 (coe v0) (coe v1) (coe v2) (coe v4) (coe v11) (coe v5)
                                  (coe v9) (coe v13))
                               (coe
                                  (\ v15 ->
                                     coe
-                                      MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                                      MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                                       (coe
                                          d_checkPointwise_304 (coe v0) (coe v1) (coe v2) (coe v10)
                                          (coe v4) (coe v5) (coe v12) (coe v14))
                                       (coe
                                          (\ v16 ->
                                             coe
-                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                               (coe
                                                  MAlonzo.Code.Data.List.Relation.Binary.Pointwise.Base.C__'8759'__62
                                                  v15 v16)))))
@@ -360,11 +360,11 @@ d_check_316 ::
   T__'8829'__102 ->
   MAlonzo.Code.VerifiedCompilation.Trace.T_InlineHints_54 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_Proof'63'_66
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_Proof'63'_78
 d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
   = let v8
           = coe
-              MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
+              MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_90
               MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_38 v4 v7 in
     coe
       (case coe v4 of
@@ -384,7 +384,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                     MAlonzo.Code.Relation.Nullary.Decidable.Core.C__because__32 v13 v14
                                       -> let v15
                                                = coe
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_90
                                                    MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_38
                                                    v4 v7 in
                                          coe
@@ -412,12 +412,12 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                                                  (case coe v20 of
                                                                                     MAlonzo.Code.Agda.Builtin.Maybe.C_just_16 v21
                                                                                       -> coe
-                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                                                                            (coe
                                                                                               C_'96'_230)
                                                                                     MAlonzo.Code.Agda.Builtin.Maybe.C_nothing_18
                                                                                       -> coe
-                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
+                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_90
                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_38
                                                                                            v4 v4
                                                                                     _ -> MAlonzo.RTE.mazUnreachableError)
@@ -430,14 +430,14 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                        _ -> coe v8
                 MAlonzo.Code.VerifiedCompilation.Trace.C_expand_58 v10
                   -> coe
-                       MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                       MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                        (coe
                           d_check_316 (coe v0) (coe v1) (coe v2) (coe v3) (coe v3 v9)
                           (coe v5) (coe v10) (coe v7))
                        (coe
                           (\ v11 ->
                              coe
-                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                (coe C_'96''8595'_234 v11)))
                 _ -> coe v8
          MAlonzo.Code.Untyped.C_ƛ_20 v9
@@ -448,7 +448,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                          -> case coe v7 of
                               MAlonzo.Code.Untyped.C_ƛ_20 v11
                                 -> coe
-                                     MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                                     MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                                      (coe
                                         d_check_316 (coe addInt (coe (1 :: Integer)) (coe v0))
                                         (coe C_'9633'_32) (coe C_'9633'_32)
@@ -459,7 +459,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                      (coe
                                         (\ v12 ->
                                            coe
-                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                              (coe C_ƛ'9633'_236 v12)))
                               _ -> coe v8
                        _ -> coe v8
@@ -473,7 +473,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                        -> case coe v7 of
                                             MAlonzo.Code.Untyped.C_ƛ_20 v19
                                               -> coe
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                                                    (coe
                                                       d_check_316
                                                       (coe addInt (coe (1 :: Integer)) (coe v0))
@@ -495,7 +495,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                    (coe
                                                       (\ v20 ->
                                                          coe
-                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                                            (coe C_ƛ_240 v20)))
                                             _ -> coe v8
                                      _ -> coe v8
@@ -507,7 +507,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                          -> case coe v2 of
                               C__'183'__34 v16 v17
                                 -> coe
-                                     MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                                     MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                                      (coe
                                         d_check_316 (coe addInt (coe (1 :: Integer)) (coe v0))
                                         (coe d__'8593''7611'_40 (coe v0) (coe v14))
@@ -530,7 +530,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                      (coe
                                         (\ v18 ->
                                            coe
-                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                              (coe C_ƛ'8595'_244 v18)))
                               _ -> coe v8
                        _ -> coe v8
@@ -541,7 +541,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                   -> case coe v7 of
                        MAlonzo.Code.Untyped.C__'183'__22 v13 v14
                          -> coe
-                              MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                              MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                               (coe
                                  d_check_316 (coe v0) (coe C__'183'__34 (coe v1) (coe v10))
                                  (coe C__'183'__34 (coe v2) (coe v10)) (coe v3) (coe v9)
@@ -549,19 +549,19 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                               (coe
                                  (\ v15 ->
                                     coe
-                                      MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                                      MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                                       (coe
                                          d_check_316 (coe v0) (coe C_'9633'_32) (coe C_'9633'_32)
                                          (coe v3) (coe v10) (coe C_'9633'_106) (coe v12) (coe v14))
                                       (coe
                                          (\ v16 ->
                                             coe
-                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                               (coe C__'183'__250 v15 v16)))))
                        _ -> coe v8
                 MAlonzo.Code.VerifiedCompilation.Trace.C__'183''8595'_64 v11
                   -> coe
-                       MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                       MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                        (coe
                           d_check_316 (coe v0) (coe C__'183'__34 (coe v1) (coe v10))
                           (coe C__'183'__34 (coe v2) (coe v10)) (coe v3) (coe v9)
@@ -569,7 +569,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                        (coe
                           (\ v12 ->
                              coe
-                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                (coe C__'183''8595'_254 v12)))
                 _ -> coe v8
          MAlonzo.Code.Untyped.C_force_24 v9
@@ -578,14 +578,14 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                   -> case coe v7 of
                        MAlonzo.Code.Untyped.C_force_24 v11
                          -> coe
-                              MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                              MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                               (coe
                                  d_check_316 (coe v0) (coe C_'9633'_32) (coe C_'9633'_32) (coe v3)
                                  (coe v9) (coe C_'9633'_106) (coe v10) (coe v11))
                               (coe
                                  (\ v12 ->
                                     coe
-                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                       (coe C_force_258 v12)))
                        _ -> coe v8
                 _ -> coe v8
@@ -595,14 +595,14 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                   -> case coe v7 of
                        MAlonzo.Code.Untyped.C_delay_26 v11
                          -> coe
-                              MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                              MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                               (coe
                                  d_check_316 (coe v0) (coe C_'9633'_32) (coe C_'9633'_32) (coe v3)
                                  (coe v9) (coe C_'9633'_106) (coe v10) (coe v11))
                               (coe
                                  (\ v12 ->
                                     coe
-                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                       (coe C_delay_262 v12)))
                        _ -> coe v8
                 _ -> coe v8
@@ -621,12 +621,12 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                         then coe
                                                seq (coe v13)
                                                (coe
-                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                                   (coe C_con_266))
                                         else coe
                                                seq (coe v13)
                                                (coe
-                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
+                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_90
                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_38
                                                   v4 v7)
                                  _ -> MAlonzo.RTE.mazUnreachableError)
@@ -655,7 +655,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                         then coe
                                                seq (coe v16)
                                                (coe
-                                                  MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                                                  MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                                                   (coe
                                                      d_checkPointwise_304 (coe v0) (coe C_'9633'_32)
                                                      (coe C_'9633'_32) (coe v11) (coe v3)
@@ -663,12 +663,12 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                   (coe
                                                      (\ v17 ->
                                                         coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                                           (coe C_constr_280 v17))))
                                         else coe
                                                seq (coe v16)
                                                (coe
-                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
+                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_90
                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_38
                                                   v4 v7)
                                  _ -> MAlonzo.RTE.mazUnreachableError)
@@ -680,14 +680,14 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                   -> case coe v7 of
                        MAlonzo.Code.Untyped.C_case_40 v13 v14
                          -> coe
-                              MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                              MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                               (coe
                                  d_check_316 (coe v0) (coe C_'9633'_32) (coe C_'9633'_32) (coe v3)
                                  (coe v9) (coe C_'9633'_106) (coe v11) (coe v13))
                               (coe
                                  (\ v15 ->
                                     coe
-                                      MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                                      MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__100
                                       (coe
                                          d_checkPointwise_304 (coe v0) (coe C_'9633'_32)
                                          (coe C_'9633'_32) (coe v12) (coe v3) (coe C_'9633'_106)
@@ -695,7 +695,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                       (coe
                                          (\ v16 ->
                                             coe
-                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                               (coe C_case_290 v15 v16)))))
                        _ -> coe v8
                 _ -> coe v8
@@ -746,12 +746,12 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                          then coe
                                                                 seq (coe v16)
                                                                 (coe
-                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                                                    (coe C_builtin_270))
                                                          else coe
                                                                 seq (coe v16)
                                                                 (coe
-                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
+                                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_90
                                                                    MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_38
                                                                    v4 v7)
                                                   _ -> MAlonzo.RTE.mazUnreachableError)
@@ -770,12 +770,12 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                           then coe
                                                                  seq (coe v16)
                                                                  (coe
-                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                                                                     (coe C_builtin_270))
                                                           else coe
                                                                  seq (coe v16)
                                                                  (coe
-                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
+                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_90
                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_38
                                                                     v4 v7)
                                                    _ -> MAlonzo.RTE.mazUnreachableError))
@@ -788,7 +788,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                   -> case coe v7 of
                        MAlonzo.Code.Untyped.C_error_46
                          -> coe
-                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_84
                               (coe C_error_292)
                        _ -> coe v8
                 _ -> coe v8
@@ -798,7 +798,7 @@ d_top'45'check_718 ::
   MAlonzo.Code.VerifiedCompilation.Trace.T_InlineHints_54 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_Proof'63'_66
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_Proof'63'_78
 d_top'45'check_718 v0 v1 v2
   = coe
       d_check_316 (coe (0 :: Integer)) (coe C_'9633'_32)

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UntypedTranslation.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UntypedTranslation.hs
@@ -88,10 +88,10 @@ d_translation'63'_160 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
-   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38) ->
+   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50) ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_translation'63'_160 v0 ~v1 v2 v3 v4 v5
   = du_translation'63'_160 v0 v2 v3 v4 v5
 du_translation'63'_160 ::
@@ -102,10 +102,10 @@ du_translation'63'_160 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
-   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38) ->
+   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50) ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 du_translation'63'_160 v0 v1 v2 v3 v4
   = let v5
           = coe
@@ -131,13 +131,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                            (let v8 = coe v2 v0 v3 v4 in
                             coe
                               (case coe v8 of
-                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v9
+                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v9
                                    -> coe
-                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                         (coe C_istranslation_88 v9)
-                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v12 v13 v14
+                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v12 v13 v14
                                    -> coe
-                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v12 v13
+                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v12 v13
                                         v14
                                  _ -> MAlonzo.RTE.mazUnreachableError)))
                  _ -> MAlonzo.RTE.mazUnreachableError in
@@ -154,13 +154,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                            -> let v11 = coe v2 v0 v3 v4 in
                                               coe
                                                 (case coe v11 of
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v12
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v12
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                           (coe C_istranslation_88 v12)
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v15 v16 v17
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v15 v16 v17
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                           v15 v16 v17
                                                    _ -> MAlonzo.RTE.mazUnreachableError)
                                          _ -> coe v6
@@ -186,7 +186,7 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                             then coe
                                                                    seq (coe v15)
                                                                    (coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                       (coe
                                                                          C_match_94 (coe C_var_22)))
                                                             else coe
@@ -194,15 +194,15 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                                    (let v16 = coe v2 v0 v3 v4 in
                                                                     coe
                                                                       (case coe v16 of
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v17
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v17
                                                                            -> coe
-                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                 (coe
                                                                                    C_istranslation_88
                                                                                    v17)
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v20 v21 v22
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v20 v21 v22
                                                                            -> coe
-                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                 v20 v21 v22
                                                                          _ -> MAlonzo.RTE.mazUnreachableError))
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
@@ -219,13 +219,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -241,13 +241,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -263,13 +263,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -285,13 +285,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -307,13 +307,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -329,13 +329,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -351,13 +351,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -373,13 +373,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -395,13 +395,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v12 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v12 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v13)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v16 v17 v18
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -419,13 +419,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                            -> let v11 = coe v2 v0 v3 v4 in
                                               coe
                                                 (case coe v11 of
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v12
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v12
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                           (coe C_istranslation_88 v12)
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v15 v16 v17
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v15 v16 v17
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                           v15 v16 v17
                                                    _ -> MAlonzo.RTE.mazUnreachableError)
                                          _ -> coe v6
@@ -443,13 +443,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -469,21 +469,21 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                           (coe v1) (coe v2) (coe v7) (coe v9) in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_match_94 (coe C_ƛ_28 v14))
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> let v20 = coe v2 v0 v3 v4 in
                                                           coe
                                                             (case coe v20 of
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v21
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v21
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                       (coe C_istranslation_88 v21)
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v24 v25 v26
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v24 v25 v26
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                       v24 v25 v26
                                                                _ -> MAlonzo.RTE.mazUnreachableError)
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
@@ -500,13 +500,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -522,13 +522,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -544,13 +544,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -566,13 +566,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -588,13 +588,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -610,13 +610,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -632,13 +632,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -654,13 +654,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v12 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v12 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v13)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v16 v17 v18
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -678,13 +678,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                            -> let v12 = coe v2 v0 v3 v4 in
                                               coe
                                                 (case coe v12 of
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                           (coe C_istranslation_88 v13)
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                           v16 v17 v18
                                                    _ -> MAlonzo.RTE.mazUnreachableError)
                                          _ -> coe v6
@@ -702,13 +702,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -724,13 +724,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -749,7 +749,7 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                           (coe v2) (coe v8) (coe v11) in
                                                 coe
                                                   (case coe v15 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v16
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v16
                                                        -> let v17
                                                                 = coe
                                                                     du_translation'63'_160 (coe v0)
@@ -757,39 +757,39 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                                     (coe v10) in
                                                           coe
                                                             (case coe v17 of
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v18
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v18
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                       (coe
                                                                          C_match_94
                                                                          (coe C_app_38 v18 v16))
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v21 v22 v23
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v21 v22 v23
                                                                  -> let v24 = coe v2 v0 v3 v4 in
                                                                     coe
                                                                       (case coe v24 of
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v25
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v25
                                                                            -> coe
-                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                 (coe
                                                                                    C_istranslation_88
                                                                                    v25)
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v28 v29 v30
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v28 v29 v30
                                                                            -> coe
-                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                 v28 v29 v30
                                                                          _ -> MAlonzo.RTE.mazUnreachableError)
                                                                _ -> MAlonzo.RTE.mazUnreachableError)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v19 v20 v21
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v19 v20 v21
                                                        -> let v22 = coe v2 v0 v3 v4 in
                                                           coe
                                                             (case coe v22 of
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v23
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v23
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                       (coe C_istranslation_88 v23)
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v26 v27 v28
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v26 v27 v28
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                       v26 v27 v28
                                                                _ -> MAlonzo.RTE.mazUnreachableError)
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
@@ -806,13 +806,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -828,13 +828,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -850,13 +850,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -872,13 +872,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v15 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v15 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v16
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v16
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v16)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v19 v20 v21
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v19 v20 v21
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v19 v20 v21
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -894,13 +894,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v15 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v15 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v16
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v16
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v16)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v19 v20 v21
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v19 v20 v21
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v19 v20 v21
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -916,13 +916,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -938,13 +938,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -962,13 +962,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                            -> let v11 = coe v2 v0 v3 v4 in
                                               coe
                                                 (case coe v11 of
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v12
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v12
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                           (coe C_istranslation_88 v12)
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v15 v16 v17
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v15 v16 v17
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                           v15 v16 v17
                                                    _ -> MAlonzo.RTE.mazUnreachableError)
                                          _ -> coe v6
@@ -986,13 +986,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1008,13 +1008,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1030,13 +1030,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1055,21 +1055,21 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                           (coe v2) (coe v7) (coe v9) in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_match_94 (coe C_force_44 v14))
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> let v20 = coe v2 v0 v3 v4 in
                                                           coe
                                                             (case coe v20 of
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v21
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v21
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                       (coe C_istranslation_88 v21)
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v24 v25 v26
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v24 v25 v26
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                       v24 v25 v26
                                                                _ -> MAlonzo.RTE.mazUnreachableError)
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
@@ -1086,13 +1086,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1108,13 +1108,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1130,13 +1130,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1152,13 +1152,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1174,13 +1174,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1196,13 +1196,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v12 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v12 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v13)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v16 v17 v18
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1220,13 +1220,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                            -> let v11 = coe v2 v0 v3 v4 in
                                               coe
                                                 (case coe v11 of
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v12
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v12
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                           (coe C_istranslation_88 v12)
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v15 v16 v17
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v15 v16 v17
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                           v15 v16 v17
                                                    _ -> MAlonzo.RTE.mazUnreachableError)
                                          _ -> coe v6
@@ -1244,13 +1244,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1266,13 +1266,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1288,13 +1288,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1310,13 +1310,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1335,21 +1335,21 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                           (coe v2) (coe v7) (coe v9) in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_match_94 (coe C_delay_50 v14))
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> let v20 = coe v2 v0 v3 v4 in
                                                           coe
                                                             (case coe v20 of
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v21
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v21
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                       (coe C_istranslation_88 v21)
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v24 v25 v26
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v24 v25 v26
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                       v24 v25 v26
                                                                _ -> MAlonzo.RTE.mazUnreachableError)
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
@@ -1366,13 +1366,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1388,13 +1388,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1410,13 +1410,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1432,13 +1432,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1454,13 +1454,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v12 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v12 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v13)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v16 v17 v18
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1478,13 +1478,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                            -> let v11 = coe v2 v0 v3 v4 in
                                               coe
                                                 (case coe v11 of
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v12
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v12
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                           (coe C_istranslation_88 v12)
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v15 v16 v17
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v15 v16 v17
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                           v15 v16 v17
                                                    _ -> MAlonzo.RTE.mazUnreachableError)
                                          _ -> coe v6
@@ -1502,13 +1502,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1524,13 +1524,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1546,13 +1546,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1568,13 +1568,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1590,13 +1590,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1619,7 +1619,7 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                             then coe
                                                                    seq (coe v15)
                                                                    (coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                       (coe
                                                                          C_match_94 (coe C_con_54)))
                                                             else coe
@@ -1627,15 +1627,15 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                                    (let v16 = coe v2 v0 v3 v4 in
                                                                     coe
                                                                       (case coe v16 of
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v17
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v17
                                                                            -> coe
-                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                 (coe
                                                                                    C_istranslation_88
                                                                                    v17)
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v20 v21 v22
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v20 v21 v22
                                                                            -> coe
-                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                 v20 v21 v22
                                                                          _ -> MAlonzo.RTE.mazUnreachableError))
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
@@ -1652,13 +1652,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1674,13 +1674,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1696,13 +1696,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1718,13 +1718,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v12 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v12 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v13)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v16 v17 v18
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -1742,13 +1742,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                            -> let v12 = coe v2 v0 v3 v4 in
                                               coe
                                                 (case coe v12 of
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                           (coe C_istranslation_88 v13)
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                           v16 v17 v18
                                                    _ -> MAlonzo.RTE.mazUnreachableError)
                                          _ -> coe v6
@@ -1766,13 +1766,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -1788,13 +1788,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -1810,13 +1810,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v15 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v15 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v16
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v16
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v16)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v19 v20 v21
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v19 v20 v21
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v19 v20 v21
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -1832,13 +1832,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -1854,13 +1854,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -1876,13 +1876,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -1897,7 +1897,7 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                            MAlonzo.Code.Relation.Nullary.Reflects.C_of'696'_22 v14
                                              -> let v15
                                                       = coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.du_decToPCE_234
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.du_decToPCE_246
                                                           (coe v1)
                                                           (coe
                                                              MAlonzo.Code.Relation.Nullary.Decidable.Core.du_map'8242'_178
@@ -1915,7 +1915,7 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                           (coe v3) (coe v4) in
                                                 coe
                                                   (case coe v15 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v16
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v16
                                                        -> let v17
                                                                 = coe
                                                                     du_decPointwiseTranslation'63'_172
@@ -1923,13 +1923,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                                     (coe v8) (coe v11) in
                                                           coe
                                                             (case coe v17 of
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v18
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v18
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                       (coe
                                                                          C_match_94
                                                                          (coe C_constr_62 v18))
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v21 v22 v23
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v21 v22 v23
                                                                  -> let v24
                                                                           = coe
                                                                               v2 v0 v3
@@ -1939,29 +1939,29 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                                                  (coe v11)) in
                                                                     coe
                                                                       (case coe v24 of
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v25
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v25
                                                                            -> coe
-                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                 (coe
                                                                                    C_istranslation_88
                                                                                    v25)
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v28 v29 v30
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v28 v29 v30
                                                                            -> coe
-                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                 v28 v29 v30
                                                                          _ -> MAlonzo.RTE.mazUnreachableError)
                                                                _ -> MAlonzo.RTE.mazUnreachableError)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v19 v20 v21
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v19 v20 v21
                                                        -> let v22 = coe v2 v0 v3 v4 in
                                                           coe
                                                             (case coe v22 of
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v23
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v23
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                       (coe C_istranslation_88 v23)
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v26 v27 v28
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v26 v27 v28
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                       v26 v27 v28
                                                                _ -> MAlonzo.RTE.mazUnreachableError)
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
@@ -1978,13 +1978,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v15 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v15 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v16
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v16
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v16)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v19 v20 v21
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v19 v20 v21
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v19 v20 v21
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -2000,13 +2000,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -2022,13 +2022,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -2046,13 +2046,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                            -> let v12 = coe v2 v0 v3 v4 in
                                               coe
                                                 (case coe v12 of
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                           (coe C_istranslation_88 v13)
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                           v16 v17 v18
                                                    _ -> MAlonzo.RTE.mazUnreachableError)
                                          _ -> coe v6
@@ -2070,13 +2070,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -2092,13 +2092,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -2114,13 +2114,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v15 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v15 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v16
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v16
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v16)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v19 v20 v21
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v19 v20 v21
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v19 v20 v21
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -2136,13 +2136,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -2158,13 +2158,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -2180,13 +2180,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -2202,13 +2202,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v15 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v15 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v16
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v16
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v16)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v19 v20 v21
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v19 v20 v21
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v19 v20 v21
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -2227,7 +2227,7 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                           (coe v2) (coe v7) (coe v10) in
                                                 coe
                                                   (case coe v15 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v16
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v16
                                                        -> let v17
                                                                 = coe
                                                                     du_decPointwiseTranslation'63'_172
@@ -2235,39 +2235,39 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                                     (coe v8) (coe v11) in
                                                           coe
                                                             (case coe v17 of
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v18
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v18
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                       (coe
                                                                          C_match_94
                                                                          (coe C_case_72 v18 v16))
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v21 v22 v23
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v21 v22 v23
                                                                  -> let v24 = coe v2 v0 v3 v4 in
                                                                     coe
                                                                       (case coe v24 of
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v25
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v25
                                                                            -> coe
-                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                 (coe
                                                                                    C_istranslation_88
                                                                                    v25)
-                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v28 v29 v30
+                                                                         MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v28 v29 v30
                                                                            -> coe
-                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                 v28 v29 v30
                                                                          _ -> MAlonzo.RTE.mazUnreachableError)
                                                                _ -> MAlonzo.RTE.mazUnreachableError)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v19 v20 v21
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v19 v20 v21
                                                        -> let v22 = coe v2 v0 v3 v4 in
                                                           coe
                                                             (case coe v22 of
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v23
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v23
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                       (coe C_istranslation_88 v23)
-                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v26 v27 v28
+                                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v26 v27 v28
                                                                  -> coe
-                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                       v26 v27 v28
                                                                _ -> MAlonzo.RTE.mazUnreachableError)
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
@@ -2284,13 +2284,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -2306,13 +2306,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v9
@@ -2330,13 +2330,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                            -> let v11 = coe v2 v0 v3 v4 in
                                               coe
                                                 (case coe v11 of
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v12
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v12
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                           (coe C_istranslation_88 v12)
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v15 v16 v17
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v15 v16 v17
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                           v15 v16 v17
                                                    _ -> MAlonzo.RTE.mazUnreachableError)
                                          _ -> coe v6
@@ -2354,13 +2354,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -2376,13 +2376,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -2398,13 +2398,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -2420,13 +2420,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -2442,13 +2442,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -2464,13 +2464,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -2486,13 +2486,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -2508,13 +2508,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v14 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v14 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v15
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v15
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v15)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v18 v19 v20
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v18 v19 v20
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v18 v19 v20
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -2577,7 +2577,7 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                                              then coe
                                                                                     seq (coe v18)
                                                                                     (coe
-                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                        (coe
                                                                                           C_match_94
                                                                                           (coe
@@ -2592,15 +2592,15 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                                                      coe
                                                                                        (case coe
                                                                                                v19 of
-                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v20
+                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v20
                                                                                             -> coe
-                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                  (coe
                                                                                                     C_istranslation_88
                                                                                                     v20)
-                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v23 v24 v25
+                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v23 v24 v25
                                                                                             -> coe
-                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                  v23
                                                                                                  v24
                                                                                                  v25
@@ -2621,7 +2621,7 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                                               then coe
                                                                                      seq (coe v18)
                                                                                      (coe
-                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                         (coe
                                                                                            C_match_94
                                                                                            (coe
@@ -2637,15 +2637,15 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                                                                       coe
                                                                                         (case coe
                                                                                                 v19 of
-                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v20
+                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v20
                                                                                              -> coe
-                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                                                                   (coe
                                                                                                      C_istranslation_88
                                                                                                      v20)
-                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v23 v24 v25
+                                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v23 v24 v25
                                                                                              -> coe
-                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                                                                   v23
                                                                                                   v24
                                                                                                   v25
@@ -2665,13 +2665,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v12 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v12 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v13)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v16 v17 v18
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v8
@@ -2689,13 +2689,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                            -> let v10 = coe v2 v0 v3 v4 in
                                               coe
                                                 (case coe v10 of
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v11
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v11
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                           (coe C_istranslation_88 v11)
-                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v14 v15 v16
+                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v14 v15 v16
                                                      -> coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                           v14 v15 v16
                                                    _ -> MAlonzo.RTE.mazUnreachableError)
                                          _ -> coe v6
@@ -2713,13 +2713,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v12 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v12 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v13)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v16 v17 v18
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v7
@@ -2735,13 +2735,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v12 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v12 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v13)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v16 v17 v18
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v7
@@ -2757,13 +2757,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v7
@@ -2779,13 +2779,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v12 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v12 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v13)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v16 v17 v18
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v7
@@ -2801,13 +2801,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v12 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v12 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v13)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v16 v17 v18
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v7
@@ -2823,13 +2823,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v12 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v12 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v13)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v16 v17 v18
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v7
@@ -2845,13 +2845,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v7
@@ -2867,13 +2867,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v13 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v13 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v14
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v14
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v14)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v17 v18 v19
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v17 v18 v19
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v17 v18 v19
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v7
@@ -2889,13 +2889,13 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                              -> let v12 = coe v2 v0 v3 v4 in
                                                 coe
                                                   (case coe v12 of
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v13
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v13
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                             (coe C_istranslation_88 v13)
-                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v16 v17 v18
+                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v16 v17 v18
                                                        -> coe
-                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
+                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64
                                                             v16 v17 v18
                                                      _ -> MAlonzo.RTE.mazUnreachableError)
                                            _ -> coe v7
@@ -2909,7 +2909,7 @@ du_translation'63'_160 v0 v1 v2 v3 v4
                                       -> case coe v9 of
                                            MAlonzo.Code.Relation.Nullary.Reflects.C_of'696'_22 v10
                                              -> coe
-                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                                   (coe C_match_94 (coe C_error_78))
                                            _ -> coe v7
                                     _ -> coe v7
@@ -2928,10 +2928,10 @@ d_decPointwiseTranslation'63'_172 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
-   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38) ->
+   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50) ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 d_decPointwiseTranslation'63'_172 v0 ~v1 v2 v3 v4 v5
   = du_decPointwiseTranslation'63'_172 v0 v2 v3 v4 v5
 du_decPointwiseTranslation'63'_172 ::
@@ -2942,28 +2942,28 @@ du_decPointwiseTranslation'63'_172 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
-   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38) ->
+   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50) ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->
-  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
+  MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_50
 du_decPointwiseTranslation'63'_172 v0 v1 v2 v3 v4
   = case coe v3 of
       []
         -> case coe v4 of
              []
                -> coe
-                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                     (coe
                        MAlonzo.Code.Data.List.Relation.Binary.Pointwise.Base.C_'91''93'_56)
              (:) v5 v6
                -> coe
-                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v1 v3 v4
+                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v1 v3 v4
              _ -> MAlonzo.RTE.mazUnreachableError
       (:) v5 v6
         -> case coe v4 of
              []
                -> coe
-                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v1 v3 v4
+                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v1 v3 v4
              (:) v7 v8
                -> let v9
                         = coe
@@ -2976,22 +2976,22 @@ du_decPointwiseTranslation'63'_172 v0 v1 v2 v3 v4
                                (coe v6) (coe v8) in
                      coe
                        (case coe v9 of
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v11
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v11
                             -> case coe v10 of
-                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44 v12
+                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56 v12
                                    -> coe
-                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
+                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_56
                                         (coe
                                            MAlonzo.Code.Data.List.Relation.Binary.Pointwise.Base.C__'8759'__62
                                            v11 v12)
-                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v15 v16 v17
+                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v15 v16 v17
                                    -> coe
-                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v15 v16
+                                        MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v15 v16
                                         v17
                                  _ -> MAlonzo.RTE.mazUnreachableError
-                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v14 v15 v16
+                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v14 v15 v16
                             -> coe
-                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52 v14 v15 v16
+                                 MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_64 v14 v15 v16
                           _ -> MAlonzo.RTE.mazUnreachableError))
              _ -> MAlonzo.RTE.mazUnreachableError
       _ -> MAlonzo.RTE.mazUnreachableError

--- a/plutus-metatheory/src/VerifiedCompilation/Certificate.lagda.md
+++ b/plutus-metatheory/src/VerifiedCompilation/Certificate.lagda.md
@@ -37,7 +37,7 @@ open import Data.Sum using (_⊎_;inj₁; inj₂)
 open import Data.List using (List; []; _∷_)
 open import Data.List.Relation.Binary.Pointwise.Base using (Pointwise)
 open import Data.List.Relation.Binary.Pointwise using (Pointwise-≡⇒≡; ≡⇒Pointwise-≡)
-open import Data.Bool.Base using (Bool; false; true; not)
+open import Data.Bool.Base using (Bool; false; true; not; T)
 open import Function.Base using (_∘_)
 
 variable
@@ -47,6 +47,15 @@ data CertResult (P : Set 𝓁) : Set (suc 𝓁) where
   proof : (p : P) → CertResult P
   ce : (¬p : ¬ P) → {X X' : Set} → OptTag → X → X' → CertResult P
   abort : {X X' : Set} → OptTag → X → X' → CertResult P
+
+is-proof : {P : Set 𝓁} → CertResult P → Bool
+is-proof (proof _) = true
+is-proof (ce  _ _ _ _) = false
+is-proof (abort _ _ _) = false
+
+-- | Reflect the proof object if there is one
+to-witness-T : ∀ {P : Set 𝓁} (p : CertResult P) → T (is-proof p) → P
+to-witness-T (proof p) _ = p
 
 -- | Result of a decision procedure: either a proof or a counterexample
 data ProofOrCE (P : Set 𝓁) : Set (suc 𝓁) where


### PR DESCRIPTION
In an Agda certificate, all work for type-checking the translation relation proofs is done in the top-level agda module. This PR instead constructs a module per pass which has the corresponding translation relation proof.  This is useful for performance debugging when type-checking an agda certificate, as we can see a break-down of the decision procedure's performance.

So in addition to `Pass_xyz/AST.agda`, there is now also `Passxyz/Proof.agda`. The top-level module simply imports the proofs and constructs the certificate proof (a big tuple). 