### PR TITLE
Bound uplc-evaluator integration test teardown and run it nightly

### DIFF
--- a/.github/workflows/nightly-testsuite.yml
+++ b/.github/workflows/nightly-testsuite.yml
@@ -1,4 +1,7 @@
-# This workflow runs the plutus-core-test and plutus-ir-test test suite.
+# This workflow runs the plutus-core-test and plutus-ir-test test suites with a
+# large number of hedgehog tests, plus the uplc-evaluator integration tests
+# (the uplc-evaluator is a non-critical on-demand tool, so its tests run nightly
+# rather than gating every PR; see plutus-private#2257).
 #
 # This workflow runs daily at midnight, and it can also be triggered manually.
 
@@ -40,3 +43,7 @@ jobs:
           pushd plutus-core
           nix run --no-warn-dirty --accept-flake-config .#plutus-ir-test -- --hedgehog-tests $HEDGEHOG_TESTS --no-create
           popd
+
+      - name: Run UPLC Evaluator Integration Tests
+        run: |
+          nix shell --no-warn-dirty --accept-flake-config .#uplc-evaluator .#uplc-evaluator-integration-tests --command uplc-evaluator-integration-tests

--- a/.github/workflows/nightly-testsuite.yml
+++ b/.github/workflows/nightly-testsuite.yml
@@ -1,7 +1,7 @@
 # This workflow runs the plutus-core-test and plutus-ir-test test suites with a
 # large number of hedgehog tests, plus the uplc-evaluator integration tests
-# (the uplc-evaluator is a non-critical on-demand tool, so its tests run nightly
-# rather than gating every PR; see plutus-private#2257).
+# (a non-critical on-demand tool whose tests run nightly rather than gating
+# every PR).
 #
 # This workflow runs daily at midnight, and it can also be triggered manually.
 

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -75,20 +75,9 @@ let
     //
     latex-documents;
 
-  # The uplc-evaluator is a non-critical, on-demand tool; its integration tests
-  # do not gate the correctness of the core compiler/evaluator and so need not
-  # run on every PR. We still BUILD the test executable on every PR (the
-  # `packages` jobs remain in `required`) and RUN the suite in the nightly
-  # testsuite workflow (.github/workflows/nightly-testsuite.yml). See
-  # plutus-private#2257. Only ghc96/ghc912 feed the x86_64-linux CI jobs.
-  without-uplc-evaluator-check = jobs: jobs // {
-    checks = removeAttrs jobs.checks
-      [ "plutus-benchmark:test:uplc-evaluator-integration-tests" ];
-  };
-
   project-variants-hydra-jobs = {
-    ghc96 = without-uplc-evaluator-check (project.flake { }).hydraJobs.ghc96;
-    ghc912 = without-uplc-evaluator-check (project.flake { }).hydraJobs.ghc912;
+    ghc96 = (project.flake { }).hydraJobs.ghc96;
+    ghc912 = (project.flake { }).hydraJobs.ghc912;
     ghc96-profiled = (project.flake { }).hydraJobs.ghc96-profiled;
     ghc912-profiled = (project.flake { }).hydraJobs.ghc912-profiled;
   };

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -48,6 +48,7 @@ let
     pir = project.flake'.packages."plutus-executables:exe:pir";
     plutus = project.flake'.packages."plutus-executables:exe:plutus";
     uplc-evaluator = project.flake'.packages."plutus-benchmark:exe:uplc-evaluator";
+    uplc-evaluator-integration-tests = project.flake'.packages."plutus-benchmark:test:uplc-evaluator-integration-tests"; # editorconfig-checker-disable-line
   };
 
   static-haskell-packages = {
@@ -74,9 +75,20 @@ let
     //
     latex-documents;
 
+  # The uplc-evaluator is a non-critical, on-demand tool; its integration tests
+  # do not gate the correctness of the core compiler/evaluator and so need not
+  # run on every PR. We still BUILD the test executable on every PR (the
+  # `packages` jobs remain in `required`) and RUN the suite in the nightly
+  # testsuite workflow (.github/workflows/nightly-testsuite.yml). See
+  # plutus-private#2257. Only ghc96/ghc912 feed the x86_64-linux CI jobs.
+  without-uplc-evaluator-check = jobs: jobs // {
+    checks = removeAttrs jobs.checks
+      [ "plutus-benchmark:test:uplc-evaluator-integration-tests" ];
+  };
+
   project-variants-hydra-jobs = {
-    ghc96 = (project.flake { }).hydraJobs.ghc96;
-    ghc912 = (project.flake { }).hydraJobs.ghc912;
+    ghc96 = without-uplc-evaluator-check (project.flake { }).hydraJobs.ghc96;
+    ghc912 = without-uplc-evaluator-check (project.flake { }).hydraJobs.ghc912;
     ghc96-profiled = (project.flake { }).hydraJobs.ghc96-profiled;
     ghc912-profiled = (project.flake { }).hydraJobs.ghc912-profiled;
   };

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -130,6 +130,12 @@ let
             plutus-tx.components.tests.plutus-tx-test.testFlags = [ "--no-create" ];
           };
         }
+        {
+          # The uplc-evaluator is a non-critical, on-demand tool. Its executable
+          # is still built on every PR, but the integration tests run only in
+          # the nightly testsuite rather than gating every PR.
+          packages.plutus-benchmark.components.tests.uplc-evaluator-integration-tests.doCheck = false;
+        }
         ({ lib, pkgs, ... }: lib.mkIf (pkgs.stdenv.hostPlatform.isWindows) {
           # This fixed basement compilation error on Windows (ref: https://ci.iog.io/build/8529222/nixlog/1)
           # ```

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -964,6 +964,7 @@ test-suite uplc-evaluator-integration-tests
     , tasty-hunit
     , temporary
     , text
+    , unix
     , uuid
     , with-utf8
 

--- a/plutus-benchmark/uplc-evaluator/test/Harness.hs
+++ b/plutus-benchmark/uplc-evaluator/test/Harness.hs
@@ -97,7 +97,9 @@ so teardown — and the whole test run — hangs (plutus-private#2257). We bound
 every blocking step instead:
 
   1. SIGTERM, then wait up to the grace period.
-  2. On expiry, SIGKILL via the raw pid, then wait (bounded again) to reap.
+  2. On expiry, re-check the exit code (the wait may have been interrupted just
+     as the process exited); if still running, SIGKILL via the raw pid, then
+     wait (bounded again) to reap.
   3. If even that expires (a process wedged in uninterruptible disk sleep can
      outlast SIGKILL), give up and leave it: the runner exits moments later and
      init reaps the orphan. Blocking here would be strictly worse.
@@ -117,13 +119,19 @@ stopProcessBounded graceMicros ph = do
   case mExit of
     Just exitCode -> reportExit exitCode
     Nothing -> do
-      hPutStrLn stderr "Service did not exit after SIGTERM; escalating to SIGKILL"
-      mPid <- getPid ph
-      mapM_ (signalProcess sigKILL) mPid
-      mExit' <- timeout graceMicros (waitForProcess ph)
-      case mExit' of
+      -- The wait may have been interrupted by 'timeout' just as the process
+      -- exited, so confirm it is still running before escalating.
+      mExited <- getProcessExitCode ph
+      case mExited of
         Just exitCode -> reportExit exitCode
-        Nothing -> hPutStrLn stderr "Service survived SIGKILL; abandoning it unreaped"
+        Nothing -> do
+          hPutStrLn stderr "Service did not exit after SIGTERM; escalating to SIGKILL"
+          mPid <- getPid ph
+          mapM_ (signalProcess sigKILL) mPid
+          mExit' <- timeout graceMicros (waitForProcess ph)
+          case mExit' of
+            Just exitCode -> reportExit exitCode
+            Nothing -> hPutStrLn stderr "Service survived SIGKILL; abandoning it unreaped"
   where
     reportExit ExitSuccess = hPutStrLn stderr "Service stopped successfully"
     reportExit (ExitFailure code) =

--- a/plutus-benchmark/uplc-evaluator/test/Harness.hs
+++ b/plutus-benchmark/uplc-evaluator/test/Harness.hs
@@ -4,15 +4,18 @@ module Harness
   ( ServiceHandle (..)
   , withEvaluatorService
   , findEvaluatorExecutable
+  , stopProcessBounded
   ) where
 
 import Control.Concurrent (threadDelay)
 import Control.Exception (bracket)
-import System.Directory (findExecutable, removeDirectoryRecursive)
+import System.Directory (findExecutable, removePathForcibly)
 import System.Exit (ExitCode (..))
 import System.IO (hPutStrLn, stderr)
 import System.IO.Temp (createTempDirectory, getCanonicalTemporaryDirectory)
+import System.Posix.Signals (sigKILL, signalProcess)
 import System.Process
+import System.Timeout (timeout)
 
 -- | Handle to a running evaluator service instance
 data ServiceHandle = ServiceHandle
@@ -74,20 +77,57 @@ withEvaluatorService executablePath action =
     stopService :: ServiceHandle -> IO ()
     stopService ServiceHandle {..} = do
       hPutStrLn stderr "Stopping uplc-evaluator service"
+      stopProcessBounded gracefulShutdownMicros shProcessHandle
 
-      -- Send SIGTERM for graceful shutdown
-      terminateProcess shProcessHandle
-
-      -- Wait for process to exit
-      exitCode <- waitForProcess shProcessHandle
-      case exitCode of
-        ExitSuccess -> hPutStrLn stderr "Service stopped successfully"
-        ExitFailure code -> hPutStrLn stderr $ "Service exited with code: " ++ show code
-
-      -- Clean up temporary directories
+      -- Clean up temporary directories. removePathForcibly tolerates the path
+      -- already being gone; an exception here fails the test loudly rather
+      -- than hanging.
       hPutStrLn stderr "Cleaning up temporary directories"
-      removeDirectoryRecursive shInputDir
-      removeDirectoryRecursive shOutputDir
+      removePathForcibly shInputDir
+      removePathForcibly shOutputDir
+
+-- | Grace period (microseconds) between SIGTERM and SIGKILL escalation.
+gracefulShutdownMicros :: Int
+gracefulShutdownMicros = 5000000 -- 5 seconds
+
+{- Note [Bounded service shutdown]
+'waitForProcess' with no timeout blocks until the child exits. If the child
+ignores or misses the SIGTERM from 'terminateProcess', that wait never returns,
+so teardown — and the whole test run — hangs (plutus-private#2257). We bound
+every blocking step instead:
+
+  1. SIGTERM, then wait up to the grace period.
+  2. On expiry, SIGKILL via the raw pid, then wait (bounded again) to reap.
+  3. If even that expires (a process wedged in uninterruptible disk sleep can
+     outlast SIGKILL), give up and leave it: the runner exits moments later and
+     init reaps the orphan. Blocking here would be strictly worse.
+
+This runs inside 'bracket''s cleanup, under interruptible 'mask'.
+'System.Timeout.timeout' relies on an async exception, and 'waitForProcess'
+blocks interruptibly on the threaded RTS (the suite is built with -threaded),
+so the timeout fires as intended.
+-}
+
+{-| Terminate a process without ever blocking indefinitely.
+See Note [Bounded service shutdown]. -}
+stopProcessBounded :: Int -> ProcessHandle -> IO ()
+stopProcessBounded graceMicros ph = do
+  terminateProcess ph
+  mExit <- timeout graceMicros (waitForProcess ph)
+  case mExit of
+    Just exitCode -> reportExit exitCode
+    Nothing -> do
+      hPutStrLn stderr "Service did not exit after SIGTERM; escalating to SIGKILL"
+      mPid <- getPid ph
+      mapM_ (signalProcess sigKILL) mPid
+      mExit' <- timeout graceMicros (waitForProcess ph)
+      case mExit' of
+        Just exitCode -> reportExit exitCode
+        Nothing -> hPutStrLn stderr "Service survived SIGKILL; abandoning it unreaped"
+  where
+    reportExit ExitSuccess = hPutStrLn stderr "Service stopped successfully"
+    reportExit (ExitFailure code) =
+      hPutStrLn stderr $ "Service exited with code: " ++ show code
 
 {-| Find the uplc-evaluator executable
 

--- a/plutus-benchmark/uplc-evaluator/test/Harness.hs
+++ b/plutus-benchmark/uplc-evaluator/test/Harness.hs
@@ -79,9 +79,6 @@ withEvaluatorService executablePath action =
       hPutStrLn stderr "Stopping uplc-evaluator service"
       stopProcessBounded gracefulShutdownMicros shProcessHandle
 
-      -- Clean up temporary directories. removePathForcibly tolerates the path
-      -- already being gone; an exception here fails the test loudly rather
-      -- than hanging.
       hPutStrLn stderr "Cleaning up temporary directories"
       removePathForcibly shInputDir
       removePathForcibly shOutputDir
@@ -91,23 +88,11 @@ gracefulShutdownMicros :: Int
 gracefulShutdownMicros = 5000000 -- 5 seconds
 
 {- Note [Bounded service shutdown]
-'waitForProcess' with no timeout blocks until the child exits. If the child
-ignores or misses the SIGTERM from 'terminateProcess', that wait never returns,
-so teardown — and the whole test run — hangs (plutus-private#2257). We bound
-every blocking step instead:
-
-  1. SIGTERM, then wait up to the grace period.
-  2. On expiry, re-check the exit code (the wait may have been interrupted just
-     as the process exited); if still running, SIGKILL via the raw pid, then
-     wait (bounded again) to reap.
-  3. If even that expires (a process wedged in uninterruptible disk sleep can
-     outlast SIGKILL), give up and leave it: the runner exits moments later and
-     init reaps the orphan. Blocking here would be strictly worse.
-
-This runs inside 'bracket''s cleanup, under interruptible 'mask'.
-'System.Timeout.timeout' relies on an async exception, and 'waitForProcess'
-blocks interruptibly on the threaded RTS (the suite is built with -threaded),
-so the timeout fires as intended.
+A plain 'waitForProcess' never returns if the child ignores SIGTERM, hanging
+teardown and the whole test run. Every wait is therefore bounded by a timeout,
+escalating SIGTERM -> SIGKILL and, as a last resort, abandoning the process
+unreaped rather than blocking. 'timeout' can interrupt 'waitForProcess' only
+because the suite is built with -threaded, where that wait is interruptible.
 -}
 
 {-| Terminate a process without ever blocking indefinitely.
@@ -119,8 +104,7 @@ stopProcessBounded graceMicros ph = do
   case mExit of
     Just exitCode -> reportExit exitCode
     Nothing -> do
-      -- The wait may have been interrupted by 'timeout' just as the process
-      -- exited, so confirm it is still running before escalating.
+      -- 'timeout' may have fired just as the process exited; re-check first.
       mExited <- getProcessExitCode ph
       case mExited of
         Just exitCode -> reportExit exitCode

--- a/plutus-benchmark/uplc-evaluator/test/Spec.hs
+++ b/plutus-benchmark/uplc-evaluator/test/Spec.hs
@@ -69,14 +69,12 @@ main = withUtf8 do
                   outputExists <- doesDirectoryExist (shOutputDir handle)
                   assertBool "Output directory should exist" outputExists
             , testCase "Bounded teardown kills a SIGTERM-ignoring process" do
-                -- Regression test for plutus-private#2257: teardown waited on
-                -- the service with no timeout, so a process that ignored or
-                -- missed SIGTERM blocked teardown indefinitely.
+                -- Regression test: teardown used to wait on the service with no
+                -- timeout, so a process ignoring SIGTERM hung it indefinitely.
                 bash <-
                   maybe (assertFailure "bash not found in PATH") pure
                     =<< findExecutable "bash"
-                -- 'trap' makes bash ignore SIGTERM; 'exec' carries that
-                -- disposition into 'sleep', which then ignores SIGTERM too.
+                -- Ignore SIGTERM, then exec so 'sleep' inherits the ignore.
                 (_, _, _, ph) <-
                   createProcess (proc bash ["-c", "trap '' TERM; exec sleep 600"])
                 threadDelay 200000 -- let bash install the trap and exec
@@ -936,9 +934,9 @@ main = withUtf8 do
             ]
         ]
 
-{-| Per-test timeout safety net (plutus-private#2257): a wedged test fails in
-minutes instead of consuming the full CI wall clock. Applied only when no
-@--timeout@ was given, so it stays overridable from the command line. -}
+{-| Per-test timeout safety net: a wedged test fails in minutes instead of
+consuming the full CI wall clock. Applied only when no @--timeout@ was given,
+so it stays overridable. -}
 defaultTestTimeout :: Timeout -> Timeout
 defaultTestTimeout NoTimeout = mkTimeout 120000000 -- 120s
 defaultTestTimeout explicit = explicit

--- a/plutus-benchmark/uplc-evaluator/test/Spec.hs
+++ b/plutus-benchmark/uplc-evaluator/test/Spec.hs
@@ -10,12 +10,19 @@ import Data.String.Interpolate (__i)
 import Data.Text qualified as T
 import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUID
-import Harness (ServiceHandle (..), findEvaluatorExecutable, withEvaluatorService)
+import GHC.Clock (getMonotonicTime)
+import Harness
+  ( ServiceHandle (..)
+  , findEvaluatorExecutable
+  , stopProcessBounded
+  , withEvaluatorService
+  )
 import Main.Utf8 (withUtf8)
-import System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
+import System.Directory (doesDirectoryExist, doesFileExist, findExecutable, listDirectory)
 import System.FilePath ((</>))
 import System.IO (BufferMode (LineBuffering), hSetBuffering, stderr, stdout)
-import Test.Tasty (defaultMain, testGroup)
+import System.Process (createProcess, getProcessExitCode, proc)
+import Test.Tasty (Timeout (..), adjustOption, defaultMain, mkTimeout, testGroup)
 import Test.Tasty.HUnit (assertBool, assertFailure, testCase, (@?=))
 import TestHelpers
   ( EvalError (..)
@@ -40,8 +47,9 @@ main = withUtf8 do
   -- Prevent garbled output from concurrent test execution
   hSetBuffering stdout LineBuffering
   hSetBuffering stderr LineBuffering
-  defaultMain
-    ( testGroup
+  defaultMain $
+    adjustOption defaultTestTimeout $
+      testGroup
         "uplc-evaluator integration tests"
         [ testGroup
             "Infrastructure"
@@ -60,6 +68,26 @@ main = withUtf8 do
                   -- Verify output directory exists
                   outputExists <- doesDirectoryExist (shOutputDir handle)
                   assertBool "Output directory should exist" outputExists
+            , testCase "Bounded teardown kills a SIGTERM-ignoring process" do
+                -- Regression test for plutus-private#2257: teardown waited on
+                -- the service with no timeout, so a process that ignored or
+                -- missed SIGTERM blocked teardown indefinitely.
+                bash <-
+                  maybe (assertFailure "bash not found in PATH") pure
+                    =<< findExecutable "bash"
+                -- 'trap' makes bash ignore SIGTERM; 'exec' carries that
+                -- disposition into 'sleep', which then ignores SIGTERM too.
+                (_, _, _, ph) <-
+                  createProcess (proc bash ["-c", "trap '' TERM; exec sleep 600"])
+                threadDelay 200000 -- let bash install the trap and exec
+                started <- getMonotonicTime
+                stopProcessBounded 1000000 ph -- 1s grace, then SIGKILL
+                finished <- getMonotonicTime
+                assertBool
+                  ("stopProcessBounded took " ++ show (finished - started) ++ "s")
+                  (finished - started < 5)
+                mExit <- getProcessExitCode ph
+                assertBool "process should be dead and reaped" (mExit /= Nothing)
             ]
         , testGroup
             "Textual UPLC Programs"
@@ -907,4 +935,10 @@ main = withUtf8 do
                     (sampleCount >= 10)
             ]
         ]
-    )
+
+{-| Per-test timeout safety net (plutus-private#2257): a wedged test fails in
+minutes instead of consuming the full CI wall clock. Applied only when no
+@--timeout@ was given, so it stays overridable from the command line. -}
+defaultTestTimeout :: Timeout -> Timeout
+defaultTestTimeout NoTimeout = mkTimeout 120000000 -- 120s
+defaultTestTimeout explicit = explicit


### PR DESCRIPTION

`plutus-benchmark:test:uplc-evaluator-integration-tests` intermittently consumed the full 2h Hydra wall clock and landed as `TIMED_OUT`, reddening `x86_64-linux.required` on unrelated PRs (IntersectMBO/plutus-private#2257). The root cause is in test teardown: `Harness.stopService` sent SIGTERM via `terminateProcess` and then called `waitForProcess` with no timeout, so any spawned `uplc-evaluator` that missed SIGTERM blocked teardown until the external CI cap. The suite starts 20+ services concurrently under tasty, so under CI load the odds of one wedging on shutdown are non-trivial.

This PR applies the three measures from the issue:

- **Bound the teardown (root cause).** `stopProcessBounded` waits a grace period after SIGTERM, then escalates to SIGKILL via `getPid` + `signalProcess`, with the post-kill reap bounded too. A process that survives even SIGKILL is left for init to reap rather than blocking teardown. Cleanup now uses `removePathForcibly`. This pulls in `unix`, which is safe because the suite is already `buildable: False` on Windows via `os-support`.
- **Add a tasty per-test timeout safety net.** The test tree is wrapped in `adjustOption defaultTestTimeout` (120s per test), applied only when no `--timeout` is given so it stays overridable. On its own it would not have fixed the hang, because when tasty times out a test the `bracket` cleanup still runs the teardown wait. So it is a safety net rather than the actual fix.
- **Take the suite off the per-PR `required` gate.** The uplc-evaluator is a non-critical on-demand tool, so its integration tests need not gate every PR. The test executable is still built on every PR (the `packages` jobs stay in `required`), so a compile break still reddens PRs; only the test run moves to the nightly testsuite workflow.

A regression test drives a SIGTERM-ignoring process (`trap '' TERM; exec sleep 600`) and asserts teardown returns in bounded time with the process actually dead.

Verified locally: the regression test fails (times out) against the old unbounded teardown and passes in ~1.2s with the fix; the full suite is 29/29 both via `cabal` and via the exact nightly `nix shell` invocation; `nix eval` confirms the `checks` jobs are gone from `required` while the `packages` builds remain.

Closes https://github.com/IntersectMBO/plutus-private/issues/2257
