### PR TITLE
Certifier: add html agda docs to metatheory documentation

### DIFF
--- a/plutus-metatheory/src/index.lagda.md
+++ b/plutus-metatheory/src/index.lagda.md
@@ -32,6 +32,13 @@ untyped version of PLC which can also be executed directly.
 The final two pieces are a type checker which is guaranteed to be
 sound and an executable that is intended to be compiled into Haskell.
 
+A separate family of modules specify UPLC compiler optimizations as syntactic
+binary relations. The relations are (semi-)decidable, so for a given pair of
+input/output terms, we can produce a proof when the pass behaved according to
+specification. This is the basis of the `--certify` flag available in the Plinth
+compiler and UPLC CLI tool. The Plinth user guide contains more detail on how to
+use the certifier.
+
 1. [Types](#types)
 2. [Normalisation of types](#normal-types)
 3. [Builtin machinery](#builtins)
@@ -41,6 +48,7 @@ sound and an executable that is intended to be compiled into Haskell.
 7. [Untyped terms](#untyped-terms)
 8. [A typechecker](#type-checker)
 9. [An executable](#executable)
+10. [Certified compilation](#certified-compilation)
 
 ## Types
 
@@ -198,5 +206,15 @@ to produce an executable.
 
 ```
 import Main
+```
+
+
+## Certified Compilation
+
+The top-level module that defines the `certify` function, imports all
+translation relations and their (semi-)decision procedures.
+
+```
+import VerifiedCompilation
 ```
 


### PR DESCRIPTION
The plutus-metatheory html docs didn't link to the certifier modules.