### PR TITLE
Update docusaurus/yarn.lock dependencies

### DIFF
--- a/doc/docusaurus/package.json
+++ b/doc/docusaurus/package.json
@@ -49,7 +49,7 @@
     "brace-expansion": "1.1.13",
     "on-headers": "1.1.0",
     "mermaid": "11.15.0",
-    "js-yaml": "3.14.2",
+    "js-yaml": "3.15.0",
     "joi": "17.13.4",
     "launch-editor": "2.14.1",
     "shell-quote": "1.8.4",

--- a/doc/docusaurus/yarn.lock
+++ b/doc/docusaurus/yarn.lock
@@ -6253,10 +6253,10 @@ joi@17.13.4, joi@^17.9.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@3.14.2, js-yaml@^3.13.1, js-yaml@^4.1.0:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+js-yaml@3.15.0, js-yaml@^3.13.1, js-yaml@^4.1.0:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
js-yaml 3.14.2 -> 3.15.0

Fixes Dependabot alert [GHSA-h67p-54hq-rp68](https://github.com/IntersectMBO/plutus/security/dependabot/125) (js-yaml quadratic-complexity DoS in merge key handling).