### PR TITLE
Add `unsafeLovelaceValueOf`: a positional lovelace accessor for ledger `Value`s

### DIFF
--- a/plutus-ledger-api/changelog.d/20260709_120000_yuriy.lazaryev_issue_2304_positional_lovelace.md
+++ b/plutus-ledger-api/changelog.d/20260709_120000_yuriy.lazaryev_issue_2304_positional_lovelace.md
@@ -1,3 +1,3 @@
 ### Added
 
-- `unsafeLovelaceValueOf`, in both `PlutusLedgerApi.V1.Value` and `PlutusLedgerApi.V1.Data.Value`: a faster, positional way to read the lovelace quantity of a ledger-provided `Value`. It returns the first amount of the first currency, skipping the ada key lookup and comparisons that `lovelaceValueOf` performs. This is sound only for `Value`s that are canonical as the ledger produces them — ada present and sorted first, as in a `TxOut` value — so it is not a drop-in replacement for `lovelaceValueOf` on mint values or user-constructed `Value`s, where ada may be absent or not first. See its Haddock for the precondition.
+- `unsafeLovelaceValueOf` in `PlutusLedgerApi.V1.Value` and `PlutusLedgerApi.V1.Data.Value`: assumes the first amount of the first currency represents lovelace without verifying this, which makes it much faster than `lovelaceValueOf`. It is sound only when this is true.

--- a/plutus-ledger-api/changelog.d/20260709_120000_yuriy.lazaryev_issue_2304_positional_lovelace.md
+++ b/plutus-ledger-api/changelog.d/20260709_120000_yuriy.lazaryev_issue_2304_positional_lovelace.md
@@ -1,0 +1,3 @@
+### Added
+
+- `unsafeLovelaceValueOf`, in both `PlutusLedgerApi.V1.Value` and `PlutusLedgerApi.V1.Data.Value`: a faster, positional way to read the lovelace quantity of a ledger-provided `Value`. It returns the first amount of the first currency, skipping the ada key lookup and comparisons that `lovelaceValueOf` performs. This is sound only for `Value`s that are canonical as the ledger produces them — ada present and sorted first, as in a `TxOut` value — so it is not a drop-in replacement for `lovelaceValueOf` on mint values or user-constructed `Value`s, where ada may be absent or not first. See its Haddock for the precondition.

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1.hs
@@ -112,6 +112,7 @@ module PlutusLedgerApi.V1
   , Value.singleton
   , Value.split
   , Value.unionWith
+  , Value.unsafeLovelaceValueOf
   , Value.valueOf
 
     -- ** Currency symbols

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
@@ -49,6 +49,7 @@ module PlutusLedgerApi.V1.Data.Value
   , currencySymbolValueOf
   , lovelaceValue
   , lovelaceValueOf
+  , unsafeLovelaceValueOf
   , scale
   , symbols
 
@@ -391,6 +392,31 @@ lovelaceValue = singleton adaSymbol adaToken . getLovelace
 lovelaceValueOf :: Value -> Lovelace
 lovelaceValueOf v = Lovelace (valueOf v adaSymbol adaToken)
 {-# INLINEABLE lovelaceValueOf #-}
+
+{-| Get the quantity of Lovelace in a ledger-provided 'Value' by reading the
+first-of-first amount positionally, without looking up the ada key.
+
+The ledger stores a 'TxOut' 'Value' in canonical form: the empty (ada)
+'CurrencySymbol' sorts first, so ada is the first outer entry; its single empty
+'TokenName' entry is the first inner entry; and every 'TxOut' carries ada
+(min-ada). The lovelace quantity is therefore exactly the first amount of the
+first currency, so it can be read as @snd . head@ twice — skipping the two
+'equalsByteString' comparisons and the key unwrapping that 'lovelaceValueOf'
+performs on the way.
+
+PRECONDITION: the 'Value' is canonical as produced by the ledger, i.e. ada is
+present and sorts first. This holds for 'TxOut' values but /not/ for mint values
+or user-constructed 'Value's, where ada may be absent or not sorted first.
+Applied to such a 'Value' this returns the first amount of whichever currency
+happens to be first (a silently wrong answer), or fails on an empty 'Value'.
+Use 'lovelaceValueOf' whenever the invariant is not guaranteed. -}
+unsafeLovelaceValueOf :: Value -> Lovelace
+unsafeLovelaceValueOf (Value mp) =
+  let outer = Map.toBuiltinList mp
+      adaTokens = BI.unsafeDataAsMap (BI.snd (BI.head outer))
+      amount = BI.snd (BI.head adaTokens)
+   in Lovelace (BI.unsafeDataAsI amount)
+{-# INLINEABLE unsafeLovelaceValueOf #-}
 
 -- | A 'Value' containing the given amount of the asset class.
 assetClassValue :: AssetClass -> Integer -> Value

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
@@ -393,23 +393,9 @@ lovelaceValueOf :: Value -> Lovelace
 lovelaceValueOf v = Lovelace (valueOf v adaSymbol adaToken)
 {-# INLINEABLE lovelaceValueOf #-}
 
-{-| Get the quantity of Lovelace in a ledger-provided 'Value' by reading the
-first-of-first amount positionally, without looking up the ada key.
-
-The ledger stores a 'TxOut' 'Value' in canonical form: the empty (ada)
-'CurrencySymbol' sorts first, so ada is the first outer entry; its single empty
-'TokenName' entry is the first inner entry; and every 'TxOut' carries ada
-(min-ada). The lovelace quantity is therefore exactly the first amount of the
-first currency, so it can be read as @snd . head@ twice — skipping the two
-'equalsByteString' comparisons and the key unwrapping that 'lovelaceValueOf'
-performs on the way.
-
-PRECONDITION: the 'Value' is canonical as produced by the ledger, i.e. ada is
-present and sorts first. This holds for 'TxOut' values but /not/ for mint values
-or user-constructed 'Value's, where ada may be absent or not sorted first.
-Applied to such a 'Value' this returns the first amount of whichever currency
-happens to be first (a silently wrong answer), or fails on an empty 'Value'.
-Use 'lovelaceValueOf' whenever the invariant is not guaranteed. -}
+{-| Assumes that the first token of the first currency in the 'Value'
+represents lovelace. Returns a silently wrong answer or fails if that's not
+the case. It is thus much faster than 'lovelaceValueOf'. -}
 unsafeLovelaceValueOf :: Value -> Lovelace
 unsafeLovelaceValueOf (Value mp) =
   let outer = Map.toBuiltinList mp

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
@@ -48,6 +48,7 @@ module PlutusLedgerApi.V1.Value
   , currencySymbolValueOf
   , lovelaceValue
   , lovelaceValueOf
+  , unsafeLovelaceValueOf
   , scale
   , symbols
 
@@ -395,6 +396,28 @@ lovelaceValue = singleton adaSymbol adaToken . getLovelace
 lovelaceValueOf :: Value -> Lovelace
 lovelaceValueOf v = Lovelace (valueOf v adaSymbol adaToken)
 {-# INLINEABLE lovelaceValueOf #-}
+
+{-| Get the quantity of Lovelace in a ledger-provided 'Value' by reading the
+first-of-first amount positionally, without looking up the ada key.
+
+The ledger stores a 'TxOut' 'Value' in canonical form: the empty (ada)
+'CurrencySymbol' sorts first, so ada is the first outer entry; its single empty
+'TokenName' entry is the first inner entry; and every 'TxOut' carries ada
+(min-ada). The lovelace quantity is therefore exactly the first amount of the
+first currency, so it can be read as @snd . head@ twice — skipping the two
+key comparisons that 'lovelaceValueOf' performs via 'Map.lookup' on the way.
+
+PRECONDITION: the 'Value' is canonical as produced by the ledger, i.e. ada is
+present and sorts first. This holds for 'TxOut' values but /not/ for mint values
+or user-constructed 'Value's, where ada may be absent or not sorted first.
+Applied to such a 'Value' this returns the first amount of whichever currency
+happens to be first (a silently wrong answer), or fails on an empty 'Value'.
+Use 'lovelaceValueOf' whenever the invariant is not guaranteed. -}
+unsafeLovelaceValueOf :: Value -> Lovelace
+unsafeLovelaceValueOf (Value mp) =
+  let adaTokens = snd (List.head (Map.toList mp))
+   in Lovelace (snd (List.head (Map.toList adaTokens)))
+{-# INLINEABLE unsafeLovelaceValueOf #-}
 
 -- | A 'Value' containing the given amount of the asset class.
 assetClassValue :: AssetClass -> Integer -> Value

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
@@ -397,22 +397,9 @@ lovelaceValueOf :: Value -> Lovelace
 lovelaceValueOf v = Lovelace (valueOf v adaSymbol adaToken)
 {-# INLINEABLE lovelaceValueOf #-}
 
-{-| Get the quantity of Lovelace in a ledger-provided 'Value' by reading the
-first-of-first amount positionally, without looking up the ada key.
-
-The ledger stores a 'TxOut' 'Value' in canonical form: the empty (ada)
-'CurrencySymbol' sorts first, so ada is the first outer entry; its single empty
-'TokenName' entry is the first inner entry; and every 'TxOut' carries ada
-(min-ada). The lovelace quantity is therefore exactly the first amount of the
-first currency, so it can be read as @snd . head@ twice — skipping the two
-key comparisons that 'lovelaceValueOf' performs via 'Map.lookup' on the way.
-
-PRECONDITION: the 'Value' is canonical as produced by the ledger, i.e. ada is
-present and sorts first. This holds for 'TxOut' values but /not/ for mint values
-or user-constructed 'Value's, where ada may be absent or not sorted first.
-Applied to such a 'Value' this returns the first amount of whichever currency
-happens to be first (a silently wrong answer), or fails on an empty 'Value'.
-Use 'lovelaceValueOf' whenever the invariant is not guaranteed. -}
+{-| Assumes that the first token of the first currency in the 'Value'
+represents lovelace. Returns a silently wrong answer or fails if that's not
+the case. It is thus much faster than 'lovelaceValueOf'. -}
 unsafeLovelaceValueOf :: Value -> Lovelace
 unsafeLovelaceValueOf (Value mp) =
   let adaTokens = snd (List.head (Map.toList mp))

--- a/plutus-ledger-api/test/Spec/V1/Data/Value.hs
+++ b/plutus-ledger-api/test/Spec/V1/Data/Value.hs
@@ -134,6 +134,22 @@ test_split = testProperty "split" . scaleTestsBy 7 $ \value ->
   let (valueL, valueR) = split value
    in Numeric.negate valueL <> valueR <=> value
 
+{-| 'unsafeLovelaceValueOf' reads the lovelace quantity of a ledger-shaped
+'Value' (ada present and sorted first) and agrees with 'lovelaceValueOf'. -}
+test_unsafeLovelaceValueOf :: TestTree
+test_unsafeLovelaceValueOf =
+  testProperty "unsafeLovelaceValueOf" . scaleTestsBy 5 $ \value lovelace ->
+    let
+      -- Put ada first with a known amount, dropping any ada the arbitrary
+      -- value already carried, to reproduce the ledger's canonical layout.
+      rest = filter ((/= adaSymbol) . fst) (valueToLists value)
+      canonical = listsToValue ((adaSymbol, [(adaToken, lovelace)]) : rest)
+     in
+      conjoin
+        [ unsafeLovelaceValueOf canonical === Lovelace lovelace
+        , unsafeLovelaceValueOf canonical === lovelaceValueOf canonical
+        ]
+
 -- | Test that the Show instance for TokenName always displays hex-encoded bytes.
 test_showTokenName :: TestTree
 test_showTokenName =
@@ -169,5 +185,6 @@ test_Value =
     , test_updateSomeTokenNames
     , test_shuffle
     , test_split
+    , test_unsafeLovelaceValueOf
     , test_showTokenName
     ]

--- a/plutus-ledger-api/test/Spec/V1/Value.hs
+++ b/plutus-ledger-api/test/Spec/V1/Value.hs
@@ -135,6 +135,22 @@ test_split = testProperty "split" . scaleTestsBy 7 $ \value ->
   let (valueL, valueR) = split value
    in Numeric.negate valueL <> valueR <=> value
 
+{-| 'unsafeLovelaceValueOf' reads the lovelace quantity of a ledger-shaped
+'Value' (ada present and sorted first) and agrees with 'lovelaceValueOf'. -}
+test_unsafeLovelaceValueOf :: TestTree
+test_unsafeLovelaceValueOf =
+  testProperty "unsafeLovelaceValueOf" . scaleTestsBy 5 $ \value lovelace ->
+    let
+      -- Put ada first with a known amount, dropping any ada the arbitrary
+      -- value already carried, to reproduce the ledger's canonical layout.
+      rest = filter ((/= adaSymbol) . fst) (valueToLists value)
+      canonical = listsToValue ((adaSymbol, [(adaToken, lovelace)]) : rest)
+     in
+      conjoin
+        [ unsafeLovelaceValueOf canonical === Lovelace lovelace
+        , unsafeLovelaceValueOf canonical === lovelaceValueOf canonical
+        ]
+
 -- | Test that builtin and non-builtin values are encoded identically in Data.
 test_toData :: TestTree
 test_toData = testProperty "toData" . scaleTestsBy 10 $ \v ->
@@ -187,6 +203,7 @@ test_Value =
     , test_updateSomeTokenNames
     , test_shuffle
     , test_split
+    , test_unsafeLovelaceValueOf
     , test_toData
     , test_fromData
     , test_showTokenName

--- a/plutus-tx-plugin/test-ledger-api/Spec/Budget.hs
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Budget.hs
@@ -31,6 +31,8 @@ tests =
   runTestNested ["test-ledger-api", "Spec", "Budget"] . pure . testNestedGhc $
     [ goldenPirReadable "gt" compiledGt
     , goldenPirReadable "currencySymbolValueOf" compiledCurrencySymbolValueOf
+    , goldenPirReadable "lovelaceValueOf" compiledLovelaceValueOf
+    , goldenPirReadable "unsafeLovelaceValueOf" compiledUnsafeLovelaceValueOf
     ]
       ++ testCases
 
@@ -42,6 +44,12 @@ compiledGeq = $$(compile [||geq||])
 
 compiledCurrencySymbolValueOf :: CompiledCode (Value -> CurrencySymbol -> Integer)
 compiledCurrencySymbolValueOf = $$(compile [||currencySymbolValueOf||])
+
+compiledLovelaceValueOf :: CompiledCode (Value -> Lovelace)
+compiledLovelaceValueOf = $$(compile [||lovelaceValueOf||])
+
+compiledUnsafeLovelaceValueOf :: CompiledCode (Value -> Lovelace)
+compiledUnsafeLovelaceValueOf = $$(compile [||unsafeLovelaceValueOf||])
 
 mkValue :: [(Integer, [(Integer, Integer)])] -> Value
 mkValue =
@@ -85,6 +93,21 @@ value3 =
     , (4, [(400, 401), (402, 403), (404, 405), (406, 407)])
     , (5, [(500, 501), (502, 503), (504, 505), (506, 507), (508, 509)])
     ]
+
+{-| A ledger-shaped @TxOut@ value: ada (the empty 'CurrencySymbol' and
+'TokenName') sorts first, followed by native assets, exactly as the ledger
+presents it to a validator. This is the canonical shape that
+'unsafeLovelaceValueOf' assumes. -}
+txOutValue :: Value
+txOutValue =
+  Value . Map.unsafeFromList $
+    (adaSymbol, Map.unsafeFromList [(adaToken, 2000000)])
+      : fmap
+        (bimap toSymbol (Map.unsafeFromList . fmap (first toToken)))
+        [ (1, [(100, 101)])
+        , (2, [(200, 201), (202, 203)])
+        , (3, [(300, 301), (302, 303), (304, 305)])
+        ]
 
 testCases :: [TestNested]
 testCases =
@@ -153,5 +176,15 @@ testCases =
       ( compiledCurrencySymbolValueOf
           `unsafeApplyCode` liftCodeDef value2
           `unsafeApplyCode` liftCodeDef (toSymbol 6)
+      )
+  , goldenEvalCekCatchBudget
+      "lovelaceValueOf"
+      ( compiledLovelaceValueOf
+          `unsafeApplyCode` liftCodeDef txOutValue
+      )
+  , goldenEvalCekCatchBudget
+      "unsafeLovelaceValueOf"
+      ( compiledUnsafeLovelaceValueOf
+          `unsafeApplyCode` liftCodeDef txOutValue
       )
   ]

--- a/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.12/lovelaceValueOf.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.12/lovelaceValueOf.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_657_760
+Memory:                 10_102
+AST Size:                  112
+Flat Size:                 208
+
+(con integer 2000000)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.12/lovelaceValueOf.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.12/lovelaceValueOf.golden.pir
@@ -1,0 +1,74 @@
+letrec
+  data (List :: * -> *) a | List_match where
+    Nil : List a
+    Cons : a -> List a -> List a
+in
+let
+  data (Tuple :: * -> * -> *) a b | Tuple_match where
+    Tuple2 : a -> b -> Tuple a b
+in
+letrec
+  !go : List (Tuple bytestring integer) -> integer
+    = \(ds : List (Tuple bytestring integer)) ->
+        List_match
+          {Tuple bytestring integer}
+          ds
+          {all dead. integer}
+          (/\dead -> 0)
+          (\(ds : Tuple bytestring integer)
+            (xs' : List (Tuple bytestring integer)) ->
+             /\dead ->
+               Tuple_match
+                 {bytestring}
+                 {integer}
+                 ds
+                 {integer}
+                 (\(c' : bytestring) (i : integer) ->
+                    case
+                      (all dead. integer)
+                      (equalsByteString # c')
+                      [(/\dead -> go xs'), (/\dead -> i)]
+                      {all dead. dead}))
+          {all dead. dead}
+in
+letrec
+  !go :
+     List (Tuple bytestring ((\k v -> List (Tuple k v)) bytestring integer)) ->
+     integer
+    = \(ds :
+          List
+            (Tuple
+               bytestring
+               ((\k v -> List (Tuple k v)) bytestring integer))) ->
+        List_match
+          {Tuple bytestring ((\k v -> List (Tuple k v)) bytestring integer)}
+          ds
+          {all dead. integer}
+          (/\dead -> 0)
+          (\(ds :
+               Tuple bytestring ((\k v -> List (Tuple k v)) bytestring integer))
+            (xs' :
+               List
+                 (Tuple
+                    bytestring
+                    ((\k v -> List (Tuple k v)) bytestring integer))) ->
+             /\dead ->
+               Tuple_match
+                 {bytestring}
+                 {(\k v -> List (Tuple k v)) bytestring integer}
+                 ds
+                 {integer}
+                 (\(c' : bytestring)
+                   (i : (\k v -> List (Tuple k v)) bytestring integer) ->
+                    case
+                      (all dead. integer)
+                      (equalsByteString # c')
+                      [(/\dead -> go xs'), (/\dead -> go i)]
+                      {all dead. dead}))
+          {all dead. dead}
+in
+\(v :
+    (\k v -> List (Tuple k v))
+      bytestring
+      ((\k v -> List (Tuple k v)) bytestring integer)) ->
+  go v

--- a/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.12/unsafeLovelaceValueOf.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.12/unsafeLovelaceValueOf.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_184_100
+Memory:                  7_500
+AST Size:                  100
+Flat Size:                 199
+
+(con integer 2000000)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.12/unsafeLovelaceValueOf.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.12/unsafeLovelaceValueOf.golden.pir
@@ -1,0 +1,76 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+in
+letrec
+  data (List :: * -> *) a | List_match where
+    Nil : List a
+    Cons : a -> List a -> List a
+in
+let
+  data (Tuple :: * -> * -> *) a b | Tuple_match where
+    Tuple2 : a -> b -> Tuple a b
+  !`$j` : (\k v -> List (Tuple k v)) bytestring integer -> integer
+    = \(b : (\k v -> List (Tuple k v)) bytestring integer) ->
+        List_match
+          {Tuple bytestring integer}
+          b
+          {all dead. integer}
+          (/\dead ->
+             let
+               !x : Unit = trace {Unit} "PT8" Unit
+             in
+             Tuple_match
+               {bytestring}
+               {integer}
+               (error {Tuple bytestring integer})
+               {integer}
+               (\(ds : bytestring) (b : integer) -> b))
+          (\(x : Tuple bytestring integer)
+            (ds : List (Tuple bytestring integer)) ->
+             /\dead ->
+               Tuple_match
+                 {bytestring}
+                 {integer}
+                 x
+                 {integer}
+                 (\(ds : bytestring) (b : integer) -> b))
+          {all dead. dead}
+in
+\(ds :
+    (\k v -> List (Tuple k v))
+      bytestring
+      ((\k v -> List (Tuple k v)) bytestring integer)) ->
+  List_match
+    {Tuple bytestring ((\k v -> List (Tuple k v)) bytestring integer)}
+    ds
+    {all dead. integer}
+    (/\dead ->
+       let
+         !x : Unit = trace {Unit} "PT8" Unit
+       in
+       Tuple_match
+         {bytestring}
+         {(\k v -> List (Tuple k v)) bytestring integer}
+         (error
+            {Tuple bytestring ((\k v -> List (Tuple k v)) bytestring integer)})
+         {integer}
+         (\(ds : bytestring)
+           (b : (\k v -> List (Tuple k v)) bytestring integer) ->
+            `$j` b))
+    (\(x : Tuple bytestring ((\k v -> List (Tuple k v)) bytestring integer))
+      (ds :
+         List
+           (Tuple
+              bytestring
+              ((\k v -> List (Tuple k v)) bytestring integer))) ->
+       /\dead ->
+         Tuple_match
+           {bytestring}
+           {(\k v -> List (Tuple k v)) bytestring integer}
+           x
+           {integer}
+           (\(ds : bytestring)
+             (b : (\k v -> List (Tuple k v)) bytestring integer) ->
+              `$j` b))
+    {all dead. dead}

--- a/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.6/lovelaceValueOf.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.6/lovelaceValueOf.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_657_760
+Memory:                 10_102
+AST Size:                  112
+Flat Size:                 208
+
+(con integer 2000000)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.6/lovelaceValueOf.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.6/lovelaceValueOf.golden.pir
@@ -1,0 +1,77 @@
+let
+  data (Tuple2 :: * -> * -> *) a b | Tuple2_match where
+    Tuple2 : a -> b -> Tuple2 a b
+in
+letrec
+  data (List :: * -> *) a | List_match where
+    Nil : List a
+    Cons : a -> List a -> List a
+in
+letrec
+  !go : List (Tuple2 bytestring integer) -> integer
+    = \(ds : List (Tuple2 bytestring integer)) ->
+        List_match
+          {Tuple2 bytestring integer}
+          ds
+          {all dead. integer}
+          (/\dead -> 0)
+          (\(ds : Tuple2 bytestring integer)
+            (xs' : List (Tuple2 bytestring integer)) ->
+             /\dead ->
+               Tuple2_match
+                 {bytestring}
+                 {integer}
+                 ds
+                 {integer}
+                 (\(c' : bytestring) (i : integer) ->
+                    case
+                      (all dead. integer)
+                      (equalsByteString # c')
+                      [(/\dead -> go xs'), (/\dead -> i)]
+                      {all dead. dead}))
+          {all dead. dead}
+in
+letrec
+  !go :
+     List
+       (Tuple2 bytestring ((\k v -> List (Tuple2 k v)) bytestring integer)) ->
+     integer
+    = \(ds :
+          List
+            (Tuple2
+               bytestring
+               ((\k v -> List (Tuple2 k v)) bytestring integer))) ->
+        List_match
+          {Tuple2 bytestring ((\k v -> List (Tuple2 k v)) bytestring integer)}
+          ds
+          {all dead. integer}
+          (/\dead -> 0)
+          (\(ds :
+               Tuple2
+                 bytestring
+                 ((\k v -> List (Tuple2 k v)) bytestring integer))
+            (xs' :
+               List
+                 (Tuple2
+                    bytestring
+                    ((\k v -> List (Tuple2 k v)) bytestring integer))) ->
+             /\dead ->
+               Tuple2_match
+                 {bytestring}
+                 {(\k v -> List (Tuple2 k v)) bytestring integer}
+                 ds
+                 {integer}
+                 (\(c' : bytestring)
+                   (i : (\k v -> List (Tuple2 k v)) bytestring integer) ->
+                    case
+                      (all dead. integer)
+                      (equalsByteString # c')
+                      [(/\dead -> go xs'), (/\dead -> go i)]
+                      {all dead. dead}))
+          {all dead. dead}
+in
+\(v :
+    (\k v -> List (Tuple2 k v))
+      bytestring
+      ((\k v -> List (Tuple2 k v)) bytestring integer)) ->
+  go v

--- a/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.6/unsafeLovelaceValueOf.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.6/unsafeLovelaceValueOf.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_232_100
+Memory:                  7_800
+AST Size:                  105
+Flat Size:                 204
+
+(con integer 2000000)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.6/unsafeLovelaceValueOf.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Budget/9.6/unsafeLovelaceValueOf.golden.pir
@@ -1,0 +1,79 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+  data (Tuple2 :: * -> * -> *) a b | Tuple2_match where
+    Tuple2 : a -> b -> Tuple2 a b
+in
+letrec
+  data (List :: * -> *) a | List_match where
+    Nil : List a
+    Cons : a -> List a -> List a
+in
+let
+  !`$j` :
+     bytestring -> (\k v -> List (Tuple2 k v)) bytestring integer -> integer
+    = \(ds : bytestring) (b : (\k v -> List (Tuple2 k v)) bytestring integer) ->
+        List_match
+          {Tuple2 bytestring integer}
+          b
+          {all dead. integer}
+          (/\dead ->
+             let
+               !x : Unit = trace {Unit} "PT8" Unit
+             in
+             Tuple2_match
+               {bytestring}
+               {integer}
+               (error {Tuple2 bytestring integer})
+               {integer}
+               (\(ds : bytestring) (b : integer) -> b))
+          (\(x : Tuple2 bytestring integer)
+            (ds : List (Tuple2 bytestring integer)) ->
+             /\dead ->
+               Tuple2_match
+                 {bytestring}
+                 {integer}
+                 x
+                 {integer}
+                 (\(ds : bytestring) (b : integer) -> b))
+          {all dead. dead}
+in
+\(ds :
+    (\k v -> List (Tuple2 k v))
+      bytestring
+      ((\k v -> List (Tuple2 k v)) bytestring integer)) ->
+  List_match
+    {Tuple2 bytestring ((\k v -> List (Tuple2 k v)) bytestring integer)}
+    ds
+    {all dead. integer}
+    (/\dead ->
+       let
+         !x : Unit = trace {Unit} "PT8" Unit
+       in
+       Tuple2_match
+         {bytestring}
+         {(\k v -> List (Tuple2 k v)) bytestring integer}
+         (error
+            {Tuple2
+               bytestring
+               ((\k v -> List (Tuple2 k v)) bytestring integer)})
+         {integer}
+         (\(ds : bytestring)
+           (b : (\k v -> List (Tuple2 k v)) bytestring integer) ->
+            `$j` ds b))
+    (\(x : Tuple2 bytestring ((\k v -> List (Tuple2 k v)) bytestring integer))
+      (ds :
+         List
+           (Tuple2
+              bytestring
+              ((\k v -> List (Tuple2 k v)) bytestring integer))) ->
+       /\dead ->
+         Tuple2_match
+           {bytestring}
+           {(\k v -> List (Tuple2 k v)) bytestring integer}
+           x
+           {integer}
+           (\(ds : bytestring)
+             (b : (\k v -> List (Tuple2 k v)) bytestring integer) ->
+              `$j` ds b))
+    {all dead. dead}

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget.hs
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget.hs
@@ -31,6 +31,8 @@ tests =
   runTestNested ["test-ledger-api", "Spec", "Data", "Budget"] . pure . testNestedGhc $
     [ goldenPirReadable "gt" compiledGt
     , goldenPirReadable "currencySymbolValueOf" compiledCurrencySymbolValueOf
+    , goldenPirReadable "lovelaceValueOf" compiledLovelaceValueOf
+    , goldenPirReadable "unsafeLovelaceValueOf" compiledUnsafeLovelaceValueOf
     ]
       ++ testCases
 
@@ -48,6 +50,12 @@ compiledMintValueBurned = $$(compile [||MintValue.mintValueBurned||])
 
 compiledCurrencySymbolValueOf :: CompiledCode (Value -> CurrencySymbol -> Integer)
 compiledCurrencySymbolValueOf = $$(compile [||currencySymbolValueOf||])
+
+compiledLovelaceValueOf :: CompiledCode (Value -> Lovelace)
+compiledLovelaceValueOf = $$(compile [||lovelaceValueOf||])
+
+compiledUnsafeLovelaceValueOf :: CompiledCode (Value -> Lovelace)
+compiledUnsafeLovelaceValueOf = $$(compile [||unsafeLovelaceValueOf||])
 
 mkValue :: [(Integer, [(Integer, Integer)])] -> Value
 mkValue = Value . mkCurrencyMap
@@ -108,6 +116,21 @@ value4 =
     , (4, [(400, -401), (402, 403), (404, 405), (406, 407)])
     , (5, [(500, -501), (502, 503), (504, 505), (506, 507), (508, -509)])
     ]
+
+{-| A ledger-shaped @TxOut@ value: ada (the empty 'CurrencySymbol' and
+'TokenName') sorts first, followed by native assets, exactly as the ledger
+presents it to a validator. This is the canonical shape that
+'unsafeLovelaceValueOf' assumes. -}
+txOutValue :: Value
+txOutValue =
+  Value . Map.unsafeFromSOPList $
+    (adaSymbol, Map.unsafeFromSOPList [(adaToken, 2000000)])
+      : fmap
+        (bimap toSymbol (Map.unsafeFromSOPList . fmap (first toToken)))
+        [ (1, [(100, 101)])
+        , (2, [(200, 201), (202, 203)])
+        , (3, [(300, 301), (302, 303), (304, 305)])
+        ]
 
 testCases :: [TestNested]
 testCases =
@@ -186,5 +209,15 @@ testCases =
       "mintValueBurned"
       ( compiledMintValueBurned
           `unsafeApplyCode` liftCodeDef value4
+      )
+  , goldenEvalCekCatchBudget
+      "lovelaceValueOf"
+      ( compiledLovelaceValueOf
+          `unsafeApplyCode` liftCodeDef txOutValue
+      )
+  , goldenEvalCekCatchBudget
+      "unsafeLovelaceValueOf"
+      ( compiledUnsafeLovelaceValueOf
+          `unsafeApplyCode` liftCodeDef txOutValue
       )
   ]

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.12/lovelaceValueOf.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.12/lovelaceValueOf.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_295_411
+Memory:                  7_430
+AST Size:                   86
+Flat Size:                 171
+
+(con integer 2000000)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.12/lovelaceValueOf.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.12/lovelaceValueOf.golden.pir
@@ -1,0 +1,46 @@
+letrec
+  !goInner : list (pair data data) -> integer
+    = \(xs : list (pair data data)) ->
+        case
+          integer
+          xs
+          [ (\(hd : pair data data) ->
+               case
+                 (all dead. list (pair data data) -> integer)
+                 (equalsByteString
+                    #
+                    (unBData (case data hd [(\(l : data) (r : data) -> l)])))
+                 [ (/\dead -> goInner)
+                 , (/\dead ->
+                      \(ds : list (pair data data)) ->
+                        unIData
+                          (case data hd [(\(l : data) (r : data) -> r)])) ]
+                 {all dead. dead})
+          , 0 ]
+in
+letrec
+  !goOuter : list (pair data data) -> integer
+    = \(xs : list (pair data data)) ->
+        case
+          integer
+          xs
+          [ (\(hd : pair data data) ->
+               case
+                 (all dead. list (pair data data) -> integer)
+                 (equalsByteString
+                    #
+                    (unBData (case data hd [(\(l : data) (r : data) -> l)])))
+                 [ (/\dead -> goOuter)
+                 , (/\dead ->
+                      \(ds : list (pair data data)) ->
+                        goInner
+                          (unMapData
+                             (case data hd [(\(l : data) (r : data) -> r)]))) ]
+                 {all dead. dead})
+          , 0 ]
+in
+\(v :
+    (\k a -> list (pair data data))
+      bytestring
+      ((\k a -> list (pair data data)) bytestring integer)) ->
+  goOuter v

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.12/unsafeLovelaceValueOf.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.12/unsafeLovelaceValueOf.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   595_767
+Memory:                  2_628
+AST Size:                   24
+Flat Size:                 110
+
+(con integer 2000000)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.12/unsafeLovelaceValueOf.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.12/unsafeLovelaceValueOf.golden.pir
@@ -1,0 +1,15 @@
+\(ds :
+    (\k a -> list (pair data data))
+      bytestring
+      ((\k a -> list (pair data data)) bytestring integer)) ->
+  unIData
+    (case
+       data
+       (headList
+          {pair data data}
+          (unMapData
+             (case
+                data
+                (headList {pair data data} ds)
+                [(\(l : data) (r : data) -> r)])))
+       [(\(l : data) (r : data) -> r)])

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.6/lovelaceValueOf.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.6/lovelaceValueOf.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_295_411
+Memory:                  7_430
+AST Size:                   86
+Flat Size:                 171
+
+(con integer 2000000)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.6/lovelaceValueOf.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.6/lovelaceValueOf.golden.pir
@@ -1,0 +1,46 @@
+letrec
+  !goInner : list (pair data data) -> integer
+    = \(xs : list (pair data data)) ->
+        case
+          integer
+          xs
+          [ (\(hd : pair data data) ->
+               case
+                 (all dead. list (pair data data) -> integer)
+                 (equalsByteString
+                    #
+                    (unBData (case data hd [(\(l : data) (r : data) -> l)])))
+                 [ (/\dead -> goInner)
+                 , (/\dead ->
+                      \(ds : list (pair data data)) ->
+                        unIData
+                          (case data hd [(\(l : data) (r : data) -> r)])) ]
+                 {all dead. dead})
+          , 0 ]
+in
+letrec
+  !goOuter : list (pair data data) -> integer
+    = \(xs : list (pair data data)) ->
+        case
+          integer
+          xs
+          [ (\(hd : pair data data) ->
+               case
+                 (all dead. list (pair data data) -> integer)
+                 (equalsByteString
+                    #
+                    (unBData (case data hd [(\(l : data) (r : data) -> l)])))
+                 [ (/\dead -> goOuter)
+                 , (/\dead ->
+                      \(ds : list (pair data data)) ->
+                        goInner
+                          (unMapData
+                             (case data hd [(\(l : data) (r : data) -> r)]))) ]
+                 {all dead. dead})
+          , 0 ]
+in
+\(v :
+    (\k a -> list (pair data data))
+      bytestring
+      ((\k a -> list (pair data data)) bytestring integer)) ->
+  goOuter v

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.6/unsafeLovelaceValueOf.golden.eval
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.6/unsafeLovelaceValueOf.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   595_767
+Memory:                  2_628
+AST Size:                   24
+Flat Size:                 110
+
+(con integer 2000000)

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.6/unsafeLovelaceValueOf.golden.pir
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Budget/9.6/unsafeLovelaceValueOf.golden.pir
@@ -1,0 +1,15 @@
+\(ds :
+    (\k a -> list (pair data data))
+      bytestring
+      ((\k a -> list (pair data data)) bytestring integer)) ->
+  unIData
+    (case
+       data
+       (headList
+          {pair data data}
+          (unMapData
+             (case
+                data
+                (headList {pair data data} ds)
+                [(\(l : data) (r : data) -> r)])))
+       [(\(l : data) (r : data) -> r)])


### PR DESCRIPTION
`unsafeLovelaceValueOf` assumes that the first token of the first currency in the Value represents lovelace. Returns a silently wrong answer or fails if that's not the case. It is thus much faster than `lovelaceValueOf`.

## Impact

Isolated budget goldens on a ledger-shaped value (ada first, then three native assets), the same input fed to both functions:

| | Data `lovelaceValueOf` | Data `unsafeLovelaceValueOf` | delta |
|---|---:|---:|---:|
| CPU | 1,295,411 | 595,767 | -54.0% |
| Memory | 7,430 | 2,628 | -64.6% |

| | Scott `lovelaceValueOf` | Scott `unsafeLovelaceValueOf` | delta |
|---|---:|---:|---:|
| CPU | 1,657,760 | 1,232,100 | -25.7% |
| Memory | 10,102 | 7,800 | -22.8% |

Both variants evaluate to the same result. Because both already short-circuit on the ada-first entry, the delta is purely the removed key extraction, comparisons, and lookup recursion, so it is a fixed saving independent of how many other assets the value carries. A validator that reads lovelace on every input and every output, a common shape, compounds it.

## Coverage

A property test in both `Spec.V1.Value` and `Spec.V1.Data.Value` checks that on a canonical ledger-shaped value `unsafeLovelaceValueOf` agrees with `lovelaceValueOf` and returns the exact lovelace amount. The budget numbers above come from new `goldenEvalCekCatchBudget` goldens; I also added PIR-readable goldens so the structural difference is visible in review. Goldens are committed for GHC 9.6 and 9.12.

Implements IntersectMBO/plutus-private#2304.
