### PR TITLE
Fix Integer narrowing in the PlutusTx.Builtins.Internal wrappers

### DIFF
--- a/plutus-tx/changelog.d/20260716_125432_yuriy.lazaryev_wrapper_integer_wraparound.md
+++ b/plutus-tx/changelog.d/20260716_125432_yuriy.lazaryev_wrapper_integer_wraparound.md
@@ -3,3 +3,6 @@
 - Evaluating the Haskell definition of `PlutusTx.Builtins.indexArray` with an index exceeding
   `maxBound :: Int` now fails, matching the builtin, instead of silently indexing with the
   wrapped value.
+- The Haskell definitions of `indexByteString`, `sliceByteString`, `readBit`, `replicateByte`
+  and `caseInteger` likewise check their integer arguments in the `Integer` domain, matching
+  the builtins, instead of silently wrapping values that exceed the machine-integer range.

--- a/plutus-tx/changelog.d/20260716_125432_yuriy.lazaryev_wrapper_integer_wraparound.md
+++ b/plutus-tx/changelog.d/20260716_125432_yuriy.lazaryev_wrapper_integer_wraparound.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Evaluating the Haskell definition of `PlutusTx.Builtins.indexArray` with an index exceeding
+  `maxBound :: Int` now fails, matching the builtin, instead of silently indexing with the
+  wrapped value.

--- a/plutus-tx/changelog.d/20260716_125432_yuriy.lazaryev_wrapper_integer_wraparound.md
+++ b/plutus-tx/changelog.d/20260716_125432_yuriy.lazaryev_wrapper_integer_wraparound.md
@@ -6,3 +6,6 @@
 - The Haskell definitions of `indexByteString`, `sliceByteString`, `readBit`, `replicateByte`
   and `caseInteger` likewise check their integer arguments in the `Integer` domain, matching
   the builtins, instead of silently wrapping values that exceed the machine-integer range.
+- The Haskell definition of `consByteString` now follows the PlutusV3 builtin semantics and
+  fails on a byte outside `[0..255]`; the PlutusV1/V2 builtins reduce the byte modulo 256
+  instead, which a single Haskell definition cannot also mirror.

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -220,6 +220,7 @@ test-suite plutus-tx-test
     Blueprint.Definition.Spec
     Blueprint.Spec
     Bool.Spec
+    Builtins.Spec
     Enum.Spec
     Eq.Spec
     List.Spec

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -242,9 +242,12 @@ appendByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinByteStri
   - For builtin semantics variant A and B, that is for PlutusV1 and PlutusV2, this reduces the first argument
     modulo 256 and will never fail.
   - For builtin semantics variant C, that is for PlutusV3, this will expect first argument to be in range
-    @[0..255]@ and fail otherwise. -}
+    @[0..255]@ and fail otherwise.
+  This definition follows the PlutusV3 semantics. -}
 consByteString :: BuiltinInteger -> BuiltinByteString -> BuiltinByteString
-consByteString n (BuiltinByteString b) = BuiltinByteString $ BS.cons (fromIntegral n) b
+consByteString n (BuiltinByteString b)
+  | 0 <= n && n <= 255 = BuiltinByteString (BS.cons (fromInteger n) b)
+  | otherwise = Haskell.error "byte out of range"
 {-# OPAQUE consByteString #-}
 
 {-| Slices the given bytestring. The first integer marks the beginning index and the

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -247,11 +247,17 @@ consByteString :: BuiltinInteger -> BuiltinByteString -> BuiltinByteString
 consByteString n (BuiltinByteString b) = BuiltinByteString $ BS.cons (fromIntegral n) b
 {-# OPAQUE consByteString #-}
 
-{-| Slices the given bytestring and never fails. The first integer marks the beginning index and the
+{-| Slices the given bytestring. The first integer marks the beginning index and the
   second marks the end. Indices are expected to be 0-indexed, and when the first integer is greater
-  than the second, it returns an empty bytestring. -}
+  than the second, it returns an empty bytestring. Fails only if either integer does not fit in a
+  machine 'Int', matching the builtin. -}
 sliceByteString :: BuiltinInteger -> BuiltinInteger -> BuiltinByteString -> BuiltinByteString
-sliceByteString start n (BuiltinByteString b) = BuiltinByteString $ BS.take (fromIntegral n) (BS.drop (fromIntegral start) b)
+sliceByteString start n (BuiltinByteString b)
+  | fitsInt start && fitsInt n =
+      BuiltinByteString (BS.take (fromInteger n) (BS.drop (fromInteger start) b))
+  | otherwise = Haskell.error "slice argument out of Int range"
+  where
+    fitsInt x = toInteger (minBound :: Int) <= x && x <= toInteger (maxBound :: Int)
 {-# OPAQUE sliceByteString #-}
 
 -- | Returns the length of the provided bytestring.
@@ -262,7 +268,9 @@ lengthOfByteString (BuiltinByteString b) = toInteger $ BS.length b
 {-| Returns the n-th byte from the bytestring. Fails if the given index is not in the range @[0..j)@,
   where @j@ is the length of the bytestring. -}
 indexByteString :: BuiltinByteString -> BuiltinInteger -> BuiltinInteger
-indexByteString (BuiltinByteString b) i = toInteger $ BS.index b (fromInteger i)
+indexByteString (BuiltinByteString b) i
+  | 0 <= i && i < toInteger (BS.length b) = toInteger (BS.index b (fromInteger i))
+  | otherwise = Haskell.error "bytestring index out of bounds"
 {-# OPAQUE indexByteString #-}
 
 -- | An empty bytestring.
@@ -1007,13 +1015,15 @@ readBit
   :: BuiltinByteString
   -> BuiltinInteger
   -> Bool
-readBit (BuiltinByteString bs) i =
-  case Bitwise.readBit bs (fromIntegral i) of
-    BuiltinFailure logs err ->
-      traceAll (logs <> pure (display err)) $
-        Haskell.error "readBit errored."
-    BuiltinSuccess b -> b
-    BuiltinSuccessWithLogs logs b -> traceAll logs b
+readBit (BuiltinByteString bs) i
+  | 0 <= i && i < 8 * toInteger (BS.length bs) =
+      case Bitwise.readBit bs (fromInteger i) of
+        BuiltinFailure logs err ->
+          traceAll (logs <> pure (display err)) $
+            Haskell.error "readBit errored."
+        BuiltinSuccess b -> b
+        BuiltinSuccessWithLogs logs b -> traceAll logs b
+  | otherwise = Haskell.error "bit index out of bounds"
 {-# OPAQUE readBit #-}
 
 {-| Writes the given bit (third argument, True for 1, False for 0) at the specified indices (second argument) in the bytestring.
@@ -1039,13 +1049,15 @@ replicateByte
   :: BuiltinInteger
   -> BuiltinInteger
   -> BuiltinByteString
-replicateByte n w8 =
-  case Bitwise.replicateByte n (fromIntegral w8) of
-    BuiltinFailure logs err ->
-      traceAll (logs <> pure (display err)) $
-        Haskell.error "byteStringReplicate errored."
-    BuiltinSuccess bs -> BuiltinByteString bs
-    BuiltinSuccessWithLogs logs bs -> traceAll logs $ BuiltinByteString bs
+replicateByte n w8
+  | 0 <= w8 && w8 <= 255 =
+      case Bitwise.replicateByte n (fromInteger w8) of
+        BuiltinFailure logs err ->
+          traceAll (logs <> pure (display err)) $
+            Haskell.error "byteStringReplicate errored."
+        BuiltinSuccess bs -> BuiltinByteString bs
+        BuiltinSuccessWithLogs logs bs -> traceAll logs $ BuiltinByteString bs
+  | otherwise = Haskell.error "byte out of range"
 {-# OPAQUE replicateByte #-}
 
 {-| Computes modular exponentiation (base^exponent mod modulus). Fails if the modulus is zero or negative,
@@ -1138,7 +1150,9 @@ scaleValue c (BuiltinValue val) =
 {-# OPAQUE scaleValue #-}
 
 caseInteger :: Integer -> [a] -> a
-caseInteger i b = b !! fromIntegral i
+caseInteger i b
+  | 0 <= i && i < toInteger (Haskell.length b) = b !! fromInteger i
+  | otherwise = Haskell.error "case index out of bounds"
 {-# OPAQUE caseInteger #-}
 
 {-| Case matching on a builtin pair. Continuation is needed here to make

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -672,7 +672,9 @@ listToArray (BuiltinList l) = BuiltinArray (Vector.fromList l)
 {-| Returns the n-th element from the array. Fails if the given index is not in the range @[0..j)@,
   where @j@ is the length of the array. -}
 indexArray :: BuiltinArray a -> BuiltinInteger -> a
-indexArray (BuiltinArray v) i = v Vector.! fromInteger i
+indexArray (BuiltinArray v) i
+  | 0 <= i && i < toInteger (Vector.length v) = Vector.unsafeIndex v (fromInteger i)
+  | otherwise = Haskell.error "array index out of bounds"
 {-# OPAQUE indexArray #-}
 
 {-

--- a/plutus-tx/test/Builtins/Spec.hs
+++ b/plutus-tx/test/Builtins/Spec.hs
@@ -3,6 +3,7 @@
 module Builtins.Spec (builtinsTests) where
 
 import Control.Exception (ErrorCall)
+import Data.ByteString.Char8 qualified as C8
 import Data.Either (isLeft)
 import PlutusCore.Test (pureTry)
 import PlutusTx.Builtins.Internal qualified as BI
@@ -26,10 +27,59 @@ builtinsTests =
         , testCase "index exceeding maxBound::Int fails" $
             throwsErrorCall (BI.indexArray arr (2 ^ (64 :: Int) + 2))
         ]
+    , testGroup
+        "indexByteString"
+        [ testCase "in-range index" $ BI.indexByteString abc 2 @?= 99
+        , testCase "index equal to length fails" $ throwsErrorCall (BI.indexByteString abc 3)
+        , testCase "negative index fails" $ throwsErrorCall (BI.indexByteString abc (-1))
+        , testCase "index exceeding maxBound::Int fails" $
+            throwsErrorCall (BI.indexByteString abc (2 ^ (64 :: Int) + 2))
+        ]
+    , testGroup
+        "sliceByteString"
+        [ testCase "in-range slice" $ unBS (BI.sliceByteString 1 2 abc) @?= C8.pack "bc"
+        , testCase "negative start clamps" $ unBS (BI.sliceByteString (-5) 2 abc) @?= C8.pack "ab"
+        , testCase "overlong length clamps" $ unBS (BI.sliceByteString 1 100 abc) @?= C8.pack "bc"
+        , testCase "start exceeding maxBound::Int fails" $
+            throwsErrorCall (BI.sliceByteString (2 ^ (64 :: Int)) 2 abc)
+        , testCase "length exceeding maxBound::Int fails" $
+            throwsErrorCall (BI.sliceByteString 0 (2 ^ (64 :: Int)) abc)
+        ]
+    , testGroup
+        "readBit"
+        [ testCase "in-range bit index" $ BI.readBit abc 0 @?= True
+        , testCase "bit index equal to bit length fails" $ throwsErrorCall (BI.readBit abc 24)
+        , testCase "negative bit index fails" $ throwsErrorCall (BI.readBit abc (-1))
+        , testCase "bit index exceeding maxBound::Int fails" $
+            throwsErrorCall (BI.readBit abc (2 ^ (64 :: Int)))
+        ]
+    , testGroup
+        "replicateByte"
+        [ testCase "in-range byte" $ unBS (BI.replicateByte 3 65) @?= C8.pack "AAA"
+        , testCase "byte above 255 fails" $ throwsErrorCall (BI.replicateByte 3 256)
+        , testCase "negative byte fails" $ throwsErrorCall (BI.replicateByte 3 (-1))
+        , testCase "negative count fails" $ throwsErrorCall (BI.replicateByte (-1) 65)
+        ]
+    , testGroup
+        "caseInteger"
+        [ testCase "in-range scrutinee" $ BI.caseInteger 1 [10 :: Integer, 20, 30] @?= 20
+        , testCase "scrutinee equal to branch count fails" $
+            throwsErrorCall (BI.caseInteger 3 [10 :: Integer, 20, 30])
+        , testCase "negative scrutinee fails" $
+            throwsErrorCall (BI.caseInteger (-1) [10 :: Integer, 20, 30])
+        , testCase "scrutinee exceeding maxBound::Int fails" $
+            throwsErrorCall (BI.caseInteger (2 ^ (64 :: Int) + 1) [10 :: Integer, 20, 30])
+        ]
     ]
   where
     arr :: BI.BuiltinArray BI.BuiltinInteger
     arr = BI.listToArray (BI.BuiltinList [10, 20, 30])
+
+    abc :: BI.BuiltinByteString
+    abc = BI.BuiltinByteString (C8.pack "abc")
+
+    unBS :: BI.BuiltinByteString -> C8.ByteString
+    unBS (BI.BuiltinByteString bs) = bs
 
     throwsErrorCall :: a -> Assertion
     throwsErrorCall x =

--- a/plutus-tx/test/Builtins/Spec.hs
+++ b/plutus-tx/test/Builtins/Spec.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Builtins.Spec (builtinsTests) where
+
+import Control.Exception (ErrorCall)
+import Data.Either (isLeft)
+import PlutusCore.Test (pureTry)
+import PlutusTx.Builtins.Internal qualified as BI
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
+import Prelude
+
+-- The wrappers must fail exactly where the on-chain builtins fail: arguments outside the
+-- builtin's domain, including integers that do not fit in a machine 'Int', are errors rather
+-- than wrap-around conversions.
+builtinsTests :: TestTree
+builtinsTests =
+  testGroup
+    "Builtins"
+    [ testGroup
+        "indexArray"
+        [ testCase "in-range index" $ BI.indexArray arr 2 @?= 30
+        , testCase "negative index fails" $ throwsErrorCall (BI.indexArray arr (-1))
+        , testCase "index equal to length fails" $ throwsErrorCall (BI.indexArray arr 3)
+        , testCase "index exceeding maxBound::Int fails" $
+            throwsErrorCall (BI.indexArray arr (2 ^ (64 :: Int) + 2))
+        ]
+    ]
+  where
+    arr :: BI.BuiltinArray BI.BuiltinInteger
+    arr = BI.listToArray (BI.BuiltinList [10, 20, 30])
+
+    throwsErrorCall :: a -> Assertion
+    throwsErrorCall x =
+      assertBool "expected the evaluation to fail" (isLeft (pureTry @ErrorCall x))

--- a/plutus-tx/test/Builtins/Spec.hs
+++ b/plutus-tx/test/Builtins/Spec.hs
@@ -28,6 +28,12 @@ builtinsTests =
             throwsErrorCall (BI.indexArray arr (2 ^ (64 :: Int) + 2))
         ]
     , testGroup
+        "consByteString"
+        [ testCase "in-range byte" $ unBS (BI.consByteString 65 abc) @?= C8.pack "Aabc"
+        , testCase "byte above 255 fails" $ throwsErrorCall (BI.consByteString 256 abc)
+        , testCase "negative byte fails" $ throwsErrorCall (BI.consByteString (-1) abc)
+        ]
+    , testGroup
         "indexByteString"
         [ testCase "in-range index" $ BI.indexByteString abc 2 @?= 99
         , testCase "index equal to length fails" $ throwsErrorCall (BI.indexByteString abc 3)

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -7,6 +7,7 @@ module Main (main) where
 
 import Blueprint.Definition.Spec qualified
 import Bool.Spec (boolTests)
+import Builtins.Spec (builtinsTests)
 import Codec.CBOR.FlatTerm qualified as FlatTerm
 import Codec.Serialise (deserialiseOrFail, serialise)
 import Codec.Serialise qualified as Serialise
@@ -47,6 +48,7 @@ tests =
     , enumTests
     , listTests
     , boolTests
+    , builtinsTests
     , eqTests
     , lawsTests
     , ordTests


### PR DESCRIPTION
Fixes pre-existing Integer-to-machine-int narrowing bugs in the `PlutusTx.Builtins.Internal` wrappers: `indexArray`, `indexByteString`, `sliceByteString`, `readBit`, `replicateByte`, and `caseInteger` checked bounds only after converting their `Integer` argument, so a value exceeding the machine range wrapped and could silently succeed off-chain where the on-chain builtin fails (e.g. `indexByteString "abc" (2^64 + 2)` returned `99` instead of failing). Each wrapper now guards in the `Integer` domain, mirroring the checked unlifting the builtins get from the machinery; `sliceByteString` keeps its clamping behaviour for in-range arguments.

`consByteString` is aligned with the PlutusV3 builtin semantics (fails on a byte outside `[0..255]`): the on-chain behaviour is permanently variant-split (PlutusV1/V2 wrap modulo 256, including post-van Rossem), so a single Haskell definition can only mirror one side, and V3 is what new Plinth code targets.

Closes IntersectMBO/plutus-private#2341
