### PR TITLE
Range-check shift/rotate amounts in the bytestring wrappers

### DIFF
--- a/plutus-tx/changelog.d/20260717_101730_yuriy.lazaryev_issue_2342_shift_rotate.md
+++ b/plutus-tx/changelog.d/20260717_101730_yuriy.lazaryev_issue_2342_shift_rotate.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- The Haskell definitions of `shiftByteString` and `rotateByteString` now fail when the shift
+  or rotation amount does not fit in a machine `Int`, matching the builtin semantics that the
+  van Rossem HF activates (variants D and E); earlier variants accept any amount on-chain.

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -933,23 +933,29 @@ BITWISE
 
 {-| Shifts the bytestring to the left if the second argument is positive, and to the right otherwise.
 Right-shifts fill with 0s from the left (logical shift); left-shifts fill with 0s from the right.
-Never fails. -}
+Fails only if the shift amount does not fit in a machine 'Int', matching builtin semantics
+variants D and E; earlier variants accept any amount. -}
 shiftByteString
   :: BuiltinByteString
   -> BuiltinInteger
   -> BuiltinByteString
-shiftByteString (BuiltinByteString bs) =
-  BuiltinByteString . Bitwise.shiftByteString bs
+shiftByteString (BuiltinByteString bs) i
+  | toInteger (minBound :: Int) <= i && i <= toInteger (maxBound :: Int) =
+      BuiltinByteString (Bitwise.shiftByteString bs i)
+  | otherwise = Haskell.error "shift amount out of Int range"
 {-# OPAQUE shiftByteString #-}
 
 {-| Rotates the bytestring to the left if the second argument is positive, and to the right otherwise.
-Never fails. -}
+Fails only if the rotation amount does not fit in a machine 'Int', matching builtin semantics
+variants D and E; earlier variants accept any amount. -}
 rotateByteString
   :: BuiltinByteString
   -> BuiltinInteger
   -> BuiltinByteString
-rotateByteString (BuiltinByteString bs) =
-  BuiltinByteString . Bitwise.rotateByteString bs
+rotateByteString (BuiltinByteString bs) i
+  | toInteger (minBound :: Int) <= i && i <= toInteger (maxBound :: Int) =
+      BuiltinByteString (Bitwise.rotateByteString bs i)
+  | otherwise = Haskell.error "rotation amount out of Int range"
 {-# OPAQUE rotateByteString #-}
 
 -- | Counts the number of bits set to 1 in the bytestring and never fails.

--- a/plutus-tx/test/Builtins/Spec.hs
+++ b/plutus-tx/test/Builtins/Spec.hs
@@ -67,6 +67,24 @@ builtinsTests =
         , testCase "negative count fails" $ throwsErrorCall (BI.replicateByte (-1) 65)
         ]
     , testGroup
+        "shiftByteString"
+        [ testCase "shift by zero is identity" $ unBS (BI.shiftByteString abc 0) @?= C8.pack "abc"
+        , testCase "overlong shift zeroes the bytestring" $
+            unBS (BI.shiftByteString abc 100) @?= C8.pack "\0\0\0"
+        , testCase "amount exceeding maxBound::Int fails" $
+            throwsErrorCall (BI.shiftByteString abc (2 ^ (64 :: Int)))
+        , testCase "amount below minBound::Int fails" $
+            throwsErrorCall (BI.shiftByteString abc (-(2 ^ (64 :: Int))))
+        ]
+    , testGroup
+        "rotateByteString"
+        [ testCase "rotation by zero is identity" $ unBS (BI.rotateByteString abc 0) @?= C8.pack "abc"
+        , testCase "rotation by the bit length is identity" $
+            unBS (BI.rotateByteString abc 24) @?= C8.pack "abc"
+        , testCase "amount exceeding maxBound::Int fails" $
+            throwsErrorCall (BI.rotateByteString abc (2 ^ (64 :: Int)))
+        ]
+    , testGroup
         "caseInteger"
         [ testCase "in-range scrutinee" $ BI.caseInteger 1 [10 :: Integer, 20, 30] @?= 20
         , testCase "scrutinee equal to branch count fails" $


### PR DESCRIPTION
The `shiftByteString` and `rotateByteString` wrappers in `PlutusTx.Builtins.Internal` pass the shift/rotation amount to `PlutusCore.Bitwise` as a full `Integer` with no range check. This matches the currently live builtin semantics (variants B/C take the amount as `IntegerCostedLiterally`), but variants D and E — which the van Rossem hard fork activates at PV11 — take the amount as a checked `Int`, failing on values outside `[-2^63, 2^63-1]`. Once PV11 is live, off-chain evaluation would silently succeed (all-zero shift result, modular rotation) where the deployed script fails phase-2 validation. Both wrappers now fail on out-of-`Int`-range amounts, mirroring D/E.

Follow-up to #7851, which fixed the analogous narrowing bugs in the other wrappers. Time-sensitive: the divergence goes live with the van Rossem HF.

Closes IntersectMBO/plutus-private#2342
