### PR TITLE
Reduce HedgehogTestLimit for assocmap and list spec

### DIFF
--- a/plutus-tx-plugin/test/AssocMap/Spec.hs
+++ b/plutus-tx-plugin/test/AssocMap/Spec.hs
@@ -46,7 +46,7 @@ goldenTests =
 
 propertyTests :: TestTree
 propertyTests =
-  localOption (HedgehogTestLimit (Just 30)) $
+  localOption (HedgehogTestLimit (Just 10)) $
     testGroup
       "Map property tests"
       [ testProperty "safeFromList" safeFromListSpec

--- a/plutus-tx-plugin/test/List/Spec.hs
+++ b/plutus-tx-plugin/test/List/Spec.hs
@@ -9,7 +9,7 @@ import List.Semantics
 
 propertyTests :: TestTree
 propertyTests =
-  localOption (HedgehogTestLimit (Just 30)) $
+  localOption (HedgehogTestLimit (Just 10)) $
     testGroup
       "List property tests"
       [ testProperty "areInverses" areInversesSpec


### PR DESCRIPTION
These tests are too slow and are a burden on the CI workers.