### PR TITLE
Compile BuiltinData transparently in the plugin

### DIFF
--- a/plutus-tx-plugin/changelog.d/20260722_140000_yuriy.lazaryev_transparent_builtin_data.md
+++ b/plutus-tx-plugin/changelog.d/20260722_140000_yuriy.lazaryev_transparent_builtin_data.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- The plugin compiles `BuiltinData` transparently: `PlutusCore.Data.Data` maps
+  to the builtin `data` type and the `BuiltinData` constructor compiles to the
+  identity. This fixes the crash on `GHC.Prim.Addr#` when GHC's worker/wrapper
+  unboxing exposes `Data` in join point types (#7716), without changing
+  `BuiltinData` itself or pessimizing generated code.

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -142,6 +142,7 @@ test-suite plutus-tx-plugin-tests
     Budget.Spec
     Budget.WithGHCOptimisations
     Budget.WithoutGHCOptimisations
+    BuiltinCasing.Lib
     BuiltinCasing.Spec
     BuiltinList.Budget.Spec
     BuiltinList.NoCasing.Spec

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -235,6 +235,7 @@ builtinNames =
   , 'Builtins.listToArray
   , 'Builtins.indexArray
   , ''Builtins.BuiltinData
+  , ''PLC.Data
   , 'Builtins.chooseData
   , 'Builtins.equalsData
   , 'Builtins.serialiseData
@@ -822,6 +823,8 @@ defineBuiltinTypes = do
   defineBuiltinType ''Builtins.BuiltinUnit . ($> annMayInline) $ PLC.toTypeAst $ Proxy @()
   defineBuiltinType ''Builtins.BuiltinString . ($> annMayInline) $ PLC.toTypeAst $ Proxy @Text
   defineBuiltinType ''Builtins.BuiltinData . ($> annMayInline) $ PLC.toTypeAst $ Proxy @PLC.Data
+  -- See Note [Transparent BuiltinData] in PlutusTx.Compiler.Expr
+  defineBuiltinType ''PLC.Data . ($> annMayInline) $ PLC.toTypeAst $ Proxy @PLC.Data
   defineBuiltinType ''Builtins.BuiltinPair . ($> annMayInline) $
     PLC.TyBuiltin () (PLC.SomeTypeIn PLC.DefaultUniProtoPair)
   defineBuiltinType ''Builtins.BuiltinList . ($> annMayInline) $

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -290,6 +290,25 @@ strip = \case
   GHC.Tick _ expr -> strip expr
   expr -> expr
 
+{- Note [Transparent BuiltinData]
+'BuiltinData' is a wrapper around 'PLC.Data' whose on-chain representation is
+exactly the builtin `data` type, i.e. the wrapper is representationally the
+identity. GHC's optimizer may therefore unwrap it: worker/wrapper unboxing of
+the single-constructor product can expose the wrapped 'PLC.Data' in join point
+type signatures (#7716). Instead of hiding the wrapper from GHC, the plugin
+compiles it transparently:
+
+  - the 'PLC.Data' type compiles to the builtin `data` type, same as
+    'BuiltinData' (see 'defineBuiltinTypes' in PlutusTx.Compiler.Builtins);
+  - an application of the 'BuiltinData' constructor compiles to its argument;
+  - a bare reference to the constructor compiles to an identity function;
+  - @case scrut of BuiltinData d -> body@ binds both the case binder and @d@
+    to the compiled scrutinee.
+
+This makes any GHC transform that exposes 'PLC.Data' harmless: both sides of
+the wrapper compile to the same PLC type.
+-}
+
 -- | Convert a reference to a data constructor, i.e. a call to it.
 compileDataConRef :: CompilingDefault uni fun m ann => GHC.DataCon -> m (PIRTerm uni fun)
 compileDataConRef dc = do
@@ -1155,6 +1174,9 @@ compileExpr mloc e = do
               compileExpr Nothing expr
         -- C# is just a wrapper around a literal
         GHC.Var (GHC.idDetails -> GHC.DataConWorkId dc) `GHC.App` arg | dc == GHC.charDataCon -> compileExpr Nothing arg
+        -- See Note [Transparent BuiltinData]
+        GHC.Var (GHC.idDetails -> GHC.DataConWorkId dc) `GHC.App` arg
+          | GHC.dataConTyCon dc == builtinDataTyCon -> compileExpr Nothing arg
         -- Handle constructors of 'Integer'
         GHC.Var (GHC.idDetails -> GHC.DataConWorkId dc) `GHC.App` arg | GHC.dataConTyCon dc == GHC.integerTyCon -> do
           i <- compileExpr Nothing arg
@@ -1226,6 +1248,12 @@ compileExpr mloc e = do
         -- locally bound vars
         GHC.Var (lookupName scope . GHC.getName -> Just (var, _def)) -> pure $ PIR.mkVar var
         -- Special kinds of id
+        -- See Note [Transparent BuiltinData]
+        GHC.Var (GHC.idDetails -> GHC.DataConWorkId dc)
+          | GHC.dataConTyCon dc == builtinDataTyCon -> do
+              n <- safeFreshName "d"
+              let dataTy = PLC.TyBuiltin annMayInline (PLC.SomeTypeIn PLC.DefaultUniData)
+              pure $ PIR.LamAbs annMayInline n dataTy (PIR.Var annMayInline n)
         GHC.Var (GHC.idDetails -> GHC.DataConWorkId dc) -> compileDataConRef dc
         -- Class ops don't have unfoldings in general (although they do if they're for one-method classes, so we
         -- want to check the unfoldings case first), see GHC:Note [ClassOp/DFun selection] for why. That
@@ -1365,6 +1393,7 @@ compileCase
   -> m (PIRTerm uni fun)
 compileCase isDead rewriteConApps binfo scrutinee binder t alts = do
   wrapTailName <- lookupGhcName 'PlutusTx.AsData.Internal.wrapTail
+  builtinDataTyCon <- lookupGhcTyCon ''BI.BuiltinData
   let
     -- See Note [Compiling AsData Matchers and Their Invocations]
     isWrapTailApp =
@@ -1386,6 +1415,25 @@ compileCase isDead rewriteConApps binfo scrutinee binder t alts = do
             -- See Note [At patterns]
             let binds = [PIR.TermBind annMayInline PIR.Strict v scrutinee']
             pure $ PIR.mkLet annMayInline PIR.NonRec binds body'
+      -- See Note [Transparent BuiltinData]
+      | GHC.DataAlt dc <- con
+      , GHC.dataConTyCon dc == builtinDataTyCon
+      , [fieldVar] <- bs -> do
+          scrutinee' <- compileExpr Nothing scrutinee
+          withVarScoped binder binderAnn (Just scrutinee') $ \v -> do
+            let vTerm = PIR.mkVar v
+            withVarScoped fieldVar annMayInline (Just vTerm) $ \fv -> do
+              body' <- compileExpr Nothing body
+              pure
+                $ PIR.mkLet
+                  annMayInline
+                  PIR.NonRec
+                  [PIR.TermBind annMayInline PIR.Strict v scrutinee']
+                $ PIR.mkLet
+                  annMayInline
+                  PIR.NonRec
+                  [PIR.TermBind annMayInline PIR.Strict fv vTerm]
+                  body'
       | rewriteConApps
       , GHC.DataAlt dataCon <- con -> do
           -- Attempt to rewrite constructor applications, since sometimes they cannot be

--- a/plutus-tx-plugin/test/BuiltinCasing/9.12/useTwiceByteString.golden.uplc
+++ b/plutus-tx-plugin/test/BuiltinCasing/9.12/useTwiceByteString.golden.uplc
@@ -1,0 +1,1 @@
+(program 1.1.0 (\bs -> (\cse -> ()) (appendByteString bs bs)))

--- a/plutus-tx-plugin/test/BuiltinCasing/9.12/useTwiceData.golden.uplc
+++ b/plutus-tx-plugin/test/BuiltinCasing/9.12/useTwiceData.golden.uplc
@@ -1,0 +1,15 @@
+(program
+   1.1.0
+   ((\forced bd ->
+       (\nt ->
+          (\`$j` ->
+             case
+               (case nt [(\x eta -> constr 0 [x]), (constr 1 [])])
+               [ (\arg -> (\ds -> force `$j`) (constrData 0 (forced arg [])))
+               , (force `$j`) ])
+            (delay
+               (case
+                  (case nt [(\x eta -> constr 0 [x]), (constr 1 [])])
+                  [(\arg -> (\ds -> ()) (constrData 0 (forced arg []))), ()])))
+         (unListData bd))
+      (force mkCons)))

--- a/plutus-tx-plugin/test/BuiltinCasing/9.12/useTwiceString.golden.uplc
+++ b/plutus-tx-plugin/test/BuiltinCasing/9.12/useTwiceString.golden.uplc
@@ -1,0 +1,1 @@
+(program 1.1.0 (\s -> (\cse -> ()) (appendString s s)))

--- a/plutus-tx-plugin/test/BuiltinCasing/9.6/useTwiceByteString.golden.uplc
+++ b/plutus-tx-plugin/test/BuiltinCasing/9.6/useTwiceByteString.golden.uplc
@@ -1,0 +1,1 @@
+(program 1.1.0 (\bs -> (\cse -> ()) (appendByteString bs bs)))

--- a/plutus-tx-plugin/test/BuiltinCasing/9.6/useTwiceData.golden.uplc
+++ b/plutus-tx-plugin/test/BuiltinCasing/9.6/useTwiceData.golden.uplc
@@ -1,0 +1,15 @@
+(program
+   1.1.0
+   ((\forced bd ->
+       (\nt ->
+          (\`$j` ->
+             case
+               (case nt [(\x eta -> constr 0 [x]), (constr 1 [])])
+               [ (\arg -> `$j` (constrData 0 (forced arg [])))
+               , (`$j` (Constr 1 [])) ])
+            (\ipv ->
+               case
+                 (case nt [(\x eta -> constr 0 [x]), (constr 1 [])])
+                 [(\arg -> (\ds -> ()) (constrData 0 (forced arg []))), ()]))
+         (unListData bd))
+      (force mkCons)))

--- a/plutus-tx-plugin/test/BuiltinCasing/9.6/useTwiceString.golden.uplc
+++ b/plutus-tx-plugin/test/BuiltinCasing/9.6/useTwiceString.golden.uplc
@@ -1,0 +1,1 @@
+(program 1.1.0 (\s -> (\cse -> ()) (appendString s s)))

--- a/plutus-tx-plugin/test/BuiltinCasing/Lib.hs
+++ b/plutus-tx-plugin/test/BuiltinCasing/Lib.hs
@@ -23,8 +23,8 @@ plugin with BuiltinCasing then tries to compile as a regular ADT, crashing on
 primitives like Addr#.
 
 Only useTwiceData reproduces that shape — its golden contains a join point,
-kept compilable by BuiltinData's second constructor (see
-Note [Opaque builtin types]).  useTwiceByteString and useTwiceString are
+kept compilable by the plugin's transparent handling of the wrapper (see
+Note [Transparent BuiltinData]).  useTwiceByteString and useTwiceString are
 canaries: their goldens pin that these wrappers are never unwrapped in the
 first place (all their operations are OPAQUE), so a change in that behaviour
 surfaces as a golden diff or compile error. -}

--- a/plutus-tx-plugin/test/BuiltinCasing/Lib.hs
+++ b/plutus-tx-plugin/test/BuiltinCasing/Lib.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# OPTIONS_GHC -fplugin Plinth.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt Plinth.Plugin:target-version=1.1.0 #-}
+
+{-# HLINT ignore "Redundant case" #-}
+
+module BuiltinCasing.Lib
+  ( useTwiceData
+  , useTwiceByteString
+  , useTwiceString
+  ) where
+
+import PlutusTx
+import PlutusTx.Builtins.Internal (unitval)
+import PlutusTx.Builtins.Internal qualified as BI
+import PlutusTx.Data.List qualified as Data.List
+import PlutusTx.Prelude
+
+{-| Regression tests for #7716.  GHC's unboxing of a single-constructor opaque
+wrapper can expose its inner type in join point type signatures, which the
+plugin with BuiltinCasing then tries to compile as a regular ADT, crashing on
+primitives like Addr#.
+
+Only useTwiceData reproduces that shape — its golden contains a join point,
+kept compilable by BuiltinData's second constructor (see
+Note [Opaque builtin types]).  useTwiceByteString and useTwiceString are
+canaries: their goldens pin that these wrappers are never unwrapped in the
+first place (all their operations are OPAQUE), so a change in that behaviour
+surfaces as a golden diff or compile error. -}
+useTwiceData :: BuiltinData -> BuiltinUnit
+useTwiceData bd =
+  case toBuiltinData (firstOf items) of
+    _ -> case toBuiltinData (firstOf items) of
+      _ -> unitval
+  where
+    items = unsafeFromBuiltinData bd
+    firstOf = Data.List.caseList' Nothing (\(h :: BuiltinData) _t -> Just h)
+
+useTwiceByteString :: BuiltinByteString -> BuiltinUnit
+useTwiceByteString bs =
+  case BI.appendByteString bs bs of
+    _ -> case BI.appendByteString bs bs of
+      _ -> unitval
+
+useTwiceString :: BuiltinString -> BuiltinUnit
+useTwiceString s =
+  case BI.appendString s s of
+    _ -> case BI.appendString s s of
+      _ -> unitval

--- a/plutus-tx-plugin/test/BuiltinCasing/Spec.hs
+++ b/plutus-tx-plugin/test/BuiltinCasing/Spec.hs
@@ -10,6 +10,7 @@ module BuiltinCasing.Spec where
 
 import Test.Tasty.Extras
 
+import BuiltinCasing.Lib qualified as Lib
 import PlutusTx (compile)
 import PlutusTx.Builtins (caseInteger, caseList, casePair)
 import PlutusTx.Builtins.Internal (chooseUnit, unitval)
@@ -42,4 +43,7 @@ tests =
       , goldenUPlcReadable "addPair" $$(compile [||addPair||])
       , goldenUPlcReadable "integerABC" $$(compile [||integerABC||])
       , goldenUPlcReadable "head" $$(compile [||head||])
+      , goldenUPlcReadable "useTwiceData" $$(compile [||Lib.useTwiceData||])
+      , goldenUPlcReadable "useTwiceByteString" $$(compile [||Lib.useTwiceByteString||])
+      , goldenUPlcReadable "useTwiceString" $$(compile [||Lib.useTwiceString||])
       ]

--- a/plutus-tx-plugin/test/StageViolation/9.12/builtinData.golden.uplc
+++ b/plutus-tx-plugin/test/StageViolation/9.12/builtinData.golden.uplc
@@ -1,12 +1,2 @@
-Error: Unsupported feature: Cannot construct a value of type: PlutusTx.Builtins.Internal.BuiltinData
-
-       This error often indicates a stage violation in Plinth compilation.
-       Variables inside compile quotations must be either:
-         • Top-level variables, or
-         • Bound inside the quotation itself
-
-       Common causes:
-         • Using a function defined in a 'where' clause: move it to the top level
-         • Referencing local variables from outside the quotation
-
-       Note: GHC can generate these unexpectedly, you may need '-fno-strictness', '-fno-specialise', '-fno-spec-constr', '-fno-unbox-strict-fields', or '-fno-unbox-small-strict-fields'.
+Error: Reference to a name which is not a local, a builtin, or an external INLINABLE function: Variable ipv
+       No unfolding

--- a/plutus-tx-plugin/test/StageViolation/9.6/builtinData.golden.uplc
+++ b/plutus-tx-plugin/test/StageViolation/9.6/builtinData.golden.uplc
@@ -1,12 +1,2 @@
-Error: Unsupported feature: Cannot construct a value of type: PlutusTx.Builtins.Internal.BuiltinData
-
-       This error often indicates a stage violation in Plinth compilation.
-       Variables inside compile quotations must be either:
-         • Top-level variables, or
-         • Bound inside the quotation itself
-
-       Common causes:
-         • Using a function defined in a 'where' clause: move it to the top level
-         • Referencing local variables from outside the quotation
-
-       Note: GHC can generate these unexpectedly, you may need '-fno-strictness', '-fno-specialise', '-fno-spec-constr', '-fno-unbox-strict-fields', or '-fno-unbox-small-strict-fields'.
+Error: Reference to a name which is not a local, a builtin, or an external INLINABLE function: Variable ipv
+       No unfolding

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -104,6 +104,15 @@ we can't handle, but also so that GHC doesn't look inside and try and get clever
 In particular, we need to use 'data' rather than 'newtype' even for simple wrappers,
 otherwise GHC gets very keen to optimize through the newtype and e.g. our users
 see 'Addr#' popping up everywhere.
+
+GHC's unboxing machinery (worker/wrapper, CPR) can still unwrap a
+single-constructor wrapper, exposing e.g. the 'PLC.Data' inside 'BuiltinData'
+in join point type signatures (#7716).  For 'BuiltinData' this is harmless:
+the plugin compiles the wrapper transparently — 'PLC.Data' maps to the same
+builtin `data` type and the constructor compiles to the identity — see
+Note [Transparent BuiltinData] in PlutusTx.Compiler.Expr.  The other opaque
+wrappers are not exposed this way because all their operations are OPAQUE, so
+GHC never sees a construction or match to unwrap.
 -}
 
 error :: BuiltinUnit -> a


### PR DESCRIPTION
Alternative to the unreachable-constructor workaround in #7719 (stacked on that branch, so the diff shows only the delta; retarget to master once #7719 merges or if it's superseded).

The plugin treats `BuiltinData` as representationally transparent: `PlutusCore.Data.Data` compiles to the builtin `data` type (same as `BuiltinData`), the `BuiltinData` constructor compiles to the identity, and a single-alternative case on it binds both the case binder and the field to the scrutinee. GHC unwrapping the wrapper (the #7716 join-point crash) then becomes harmless instead of fatal, so `BuiltinDataUnreachable` and its COMPLETE pragma are removed. Details in Note [Transparent BuiltinData] in `PlutusTx.Compiler.Expr`.

The GHC 9.12 budget goldens return exactly to master's numbers — the ~1% CPU / ~2.5% memory cost of blocking GHC's unboxing is gone. Both plugin test suites pass under GHC 9.6 and 9.12 (847 + 81).

One diagnostic change: `StageViolation/builtinData` now reports the unwrapped binding (`ipv … No unfolding, Type: PlutusCore.Data.Data`) instead of `validator :: BuiltinData`, because GHC unwraps the where-binding again; the stage-violation hint and remediation notes are unchanged.