### PR TITLE
Expand AsData budget tests for dropList

### DIFF
--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richInts1.golden.eval
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richInts1.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_376_582
+Memory:                  7_996
+AST Size:                   78
+Flat Size:                  93
+
+(con integer 16)

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richInts1.golden.pir
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richInts1.golden.pir
@@ -1,0 +1,107 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+in
+\(d : data) ->
+  case
+    integer
+    ((let
+         b = list data
+       in
+       \(x : pair integer b) -> case b x [(\(l : integer) (r : b) -> r)])
+       (unConstrData d))
+    [ (\(ds : data)
+        (ds : list data) ->
+         case
+           integer
+           ds
+           [ (\(ds : data)
+               (ds : list data) ->
+                case
+                  integer
+                  ds
+                  [ (\(ds : data)
+                      (ds : list data) ->
+                       case
+                         integer
+                         ds
+                         [ (\(ds : data)
+                             (ds : list data) ->
+                              case
+                                integer
+                                ds
+                                [ (\(ds : data)
+                                    (ds : list data) ->
+                                     case
+                                       integer
+                                       ds
+                                       [ (\(ds : data)
+                                           (ds : list data) ->
+                                            case
+                                              integer
+                                              ds
+                                              [ (\(ds : data)
+                                                  (ds : list data) ->
+                                                   case
+                                                     integer
+                                                     ds
+                                                     [ (\(ds : data)
+                                                         (ds : list data) ->
+                                                          case
+                                                            integer
+                                                            ds
+                                                            [ (\(ds : data)
+                                                                (ds :
+                                                                   list data) ->
+                                                                 case
+                                                                   integer
+                                                                   ds
+                                                                   [ (\(ds :
+                                                                          data)
+                                                                       (ds :
+                                                                          list
+                                                                            data) ->
+                                                                        case
+                                                                          integer
+                                                                          ds
+                                                                          [ (\(ds :
+                                                                                 data)
+                                                                              (ds :
+                                                                                 list
+                                                                                   data) ->
+                                                                               case
+                                                                                 integer
+                                                                                 ds
+                                                                                 [ (\(ds :
+                                                                                        data)
+                                                                                     (ds :
+                                                                                        list
+                                                                                          data) ->
+                                                                                      case
+                                                                                        integer
+                                                                                        ds
+                                                                                        [ (\(ds :
+                                                                                               data)
+                                                                                            (ds :
+                                                                                               list
+                                                                                                 data) ->
+                                                                                             case
+                                                                                               integer
+                                                                                               ds
+                                                                                               [ (\(ds :
+                                                                                                      data)
+                                                                                                   (ds :
+                                                                                                      list
+                                                                                                        data) ->
+                                                                                                    case
+                                                                                                      integer
+                                                                                                      ds
+                                                                                                      [ (\(ds :
+                                                                                                             data)
+                                                                                                          (ds :
+                                                                                                             list
+                                                                                                               data) ->
+                                                                                                           unIData
+                                                                                                             (headList
+                                                                                                                {data}
+                                                                                                                ds)) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richInts1.golden.uplc
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richInts1.golden.uplc
@@ -1,0 +1,68 @@
+(program
+   1.1.0
+   ((\forced
+      d ->
+       case
+         (case (unConstrData d) [(\l r -> r)])
+         [ (\ds
+             ds ->
+              case
+                ds
+                [ (\ds
+                    ds ->
+                     case
+                       ds
+                       [ (\ds
+                           ds ->
+                            case
+                              ds
+                              [ (\ds
+                                  ds ->
+                                   case
+                                     ds
+                                     [ (\ds
+                                         ds ->
+                                          case
+                                            ds
+                                            [ (\ds
+                                                ds ->
+                                                 case
+                                                   ds
+                                                   [ (\ds
+                                                       ds ->
+                                                        case
+                                                          ds
+                                                          [ (\ds
+                                                              ds ->
+                                                               case
+                                                                 ds
+                                                                 [ (\ds
+                                                                     ds ->
+                                                                      case
+                                                                        ds
+                                                                        [ (\ds
+                                                                            ds ->
+                                                                             case
+                                                                               ds
+                                                                               [ (\ds
+                                                                                   ds ->
+                                                                                    case
+                                                                                      ds
+                                                                                      [ (\ds
+                                                                                          ds ->
+                                                                                           case
+                                                                                             ds
+                                                                                             [ (\ds
+                                                                                                 ds ->
+                                                                                                  case
+                                                                                                    ds
+                                                                                                    [ (\ds
+                                                                                                        ds ->
+                                                                                                         case
+                                                                                                           ds
+                                                                                                           [ (\ds
+                                                                                                               ds ->
+                                                                                                                unIData
+                                                                                                                  (forced
+                                                                                                                     ds)) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])
+      (force headList)))

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richInts2.golden.eval
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richInts2.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_351_384
+Memory:                  7_598
+AST Size:                   74
+Flat Size:                  91
+
+(con integer 23)

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richInts2.golden.pir
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richInts2.golden.pir
@@ -1,0 +1,100 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+in
+\(d : data) ->
+  case
+    integer
+    ((let
+         b = list data
+       in
+       \(x : pair integer b) -> case b x [(\(l : integer) (r : b) -> r)])
+       (unConstrData d))
+    [ (\(ds : data)
+        (ds : list data) ->
+         case
+           integer
+           ds
+           [ (\(ds : data)
+               (ds : list data) ->
+                case
+                  integer
+                  ds
+                  [ (\(ds : data)
+                      (ds : list data) ->
+                       case
+                         integer
+                         ds
+                         [ (\(ds : data)
+                             (ds : list data) ->
+                              case
+                                integer
+                                ds
+                                [ (\(ds : data)
+                                    (ds : list data) ->
+                                     case
+                                       integer
+                                       ds
+                                       [ (\(ds : data)
+                                           (ds : list data) ->
+                                            case
+                                              integer
+                                              ds
+                                              [ (\(ds : data)
+                                                  (ds : list data) ->
+                                                   case
+                                                     integer
+                                                     ds
+                                                     [ (\(ds : data)
+                                                         (ds : list data) ->
+                                                          case
+                                                            integer
+                                                            ds
+                                                            [ (\(ds : data)
+                                                                (ds :
+                                                                   list data) ->
+                                                                 case
+                                                                   integer
+                                                                   ds
+                                                                   [ (\(ds :
+                                                                          data)
+                                                                       (ds :
+                                                                          list
+                                                                            data) ->
+                                                                        case
+                                                                          integer
+                                                                          ds
+                                                                          [ (\(ds :
+                                                                                 data)
+                                                                              (ds :
+                                                                                 list
+                                                                                   data) ->
+                                                                               case
+                                                                                 integer
+                                                                                 ds
+                                                                                 [ (\(ds :
+                                                                                        data)
+                                                                                     (ds :
+                                                                                        list
+                                                                                          data) ->
+                                                                                      case
+                                                                                        integer
+                                                                                        ds
+                                                                                        [ (\(ds :
+                                                                                               data)
+                                                                                            (ds :
+                                                                                               list
+                                                                                                 data) ->
+                                                                                             case
+                                                                                               integer
+                                                                                               ds
+                                                                                               [ (\(ds :
+                                                                                                      data)
+                                                                                                   (ds :
+                                                                                                      list
+                                                                                                        data) ->
+                                                                                                    addInteger
+                                                                                                      (unIData
+                                                                                                         ds)
+                                                                                                      (unIData
+                                                                                                         ds)) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richInts2.golden.uplc
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richInts2.golden.uplc
@@ -1,0 +1,64 @@
+(program
+   1.1.0
+   (\d ->
+      case
+        (case (unConstrData d) [(\l r -> r)])
+        [ (\ds
+            ds ->
+             case
+               ds
+               [ (\ds
+                   ds ->
+                    case
+                      ds
+                      [ (\ds
+                          ds ->
+                           case
+                             ds
+                             [ (\ds
+                                 ds ->
+                                  case
+                                    ds
+                                    [ (\ds
+                                        ds ->
+                                         case
+                                           ds
+                                           [ (\ds
+                                               ds ->
+                                                case
+                                                  ds
+                                                  [ (\ds
+                                                      ds ->
+                                                       case
+                                                         ds
+                                                         [ (\ds
+                                                             ds ->
+                                                              case
+                                                                ds
+                                                                [ (\ds
+                                                                    ds ->
+                                                                     case
+                                                                       ds
+                                                                       [ (\ds
+                                                                           ds ->
+                                                                            case
+                                                                              ds
+                                                                              [ (\ds
+                                                                                  ds ->
+                                                                                   case
+                                                                                     ds
+                                                                                     [ (\ds
+                                                                                         ds ->
+                                                                                          case
+                                                                                            ds
+                                                                                            [ (\ds
+                                                                                                ds ->
+                                                                                                 case
+                                                                                                   ds
+                                                                                                   [ (\ds
+                                                                                                       ds ->
+                                                                                                        addInteger
+                                                                                                          (unIData
+                                                                                                             ds)
+                                                                                                          (unIData
+                                                                                                             ds)) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]))

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richInts3.golden.eval
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richInts3.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_633_336
+Memory:                  8_632
+AST Size:                   84
+Flat Size:                 100
+
+(con integer 27)

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richInts3.golden.pir
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richInts3.golden.pir
@@ -1,0 +1,111 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+in
+\(d : data) ->
+  case
+    integer
+    ((let
+         b = list data
+       in
+       \(x : pair integer b) -> case b x [(\(l : integer) (r : b) -> r)])
+       (unConstrData d))
+    [ (\(ds : data)
+        (ds : list data) ->
+         case
+           integer
+           ds
+           [ (\(ds : data)
+               (ds : list data) ->
+                case
+                  integer
+                  ds
+                  [ (\(ds : data)
+                      (ds : list data) ->
+                       case
+                         integer
+                         ds
+                         [ (\(ds : data)
+                             (ds : list data) ->
+                              case
+                                integer
+                                ds
+                                [ (\(ds : data)
+                                    (ds : list data) ->
+                                     case
+                                       integer
+                                       ds
+                                       [ (\(ds : data)
+                                           (ds : list data) ->
+                                            case
+                                              integer
+                                              ds
+                                              [ (\(ds : data)
+                                                  (ds : list data) ->
+                                                   case
+                                                     integer
+                                                     ds
+                                                     [ (\(ds : data)
+                                                         (ds : list data) ->
+                                                          case
+                                                            integer
+                                                            ds
+                                                            [ (\(ds : data)
+                                                                (ds :
+                                                                   list data) ->
+                                                                 case
+                                                                   integer
+                                                                   ds
+                                                                   [ (\(ds :
+                                                                          data)
+                                                                       (ds :
+                                                                          list
+                                                                            data) ->
+                                                                        case
+                                                                          integer
+                                                                          ds
+                                                                          [ (\(ds :
+                                                                                 data)
+                                                                              (ds :
+                                                                                 list
+                                                                                   data) ->
+                                                                               case
+                                                                                 integer
+                                                                                 ds
+                                                                                 [ (\(ds :
+                                                                                        data)
+                                                                                     (ds :
+                                                                                        list
+                                                                                          data) ->
+                                                                                      case
+                                                                                        integer
+                                                                                        ds
+                                                                                        [ (\(ds :
+                                                                                               data)
+                                                                                            (ds :
+                                                                                               list
+                                                                                                 data) ->
+                                                                                             case
+                                                                                               integer
+                                                                                               ds
+                                                                                               [ (\(ds :
+                                                                                                      data)
+                                                                                                   (ds :
+                                                                                                      list
+                                                                                                        data) ->
+                                                                                                    case
+                                                                                                      integer
+                                                                                                      ds
+                                                                                                      [ (\(ds :
+                                                                                                             data)
+                                                                                                          (ds :
+                                                                                                             list
+                                                                                                               data) ->
+                                                                                                           addInteger
+                                                                                                             (unIData
+                                                                                                                ds)
+                                                                                                             (addInteger
+                                                                                                                (unIData
+                                                                                                                   ds)
+                                                                                                                (unIData
+                                                                                                                   ds))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richInts3.golden.uplc
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richInts3.golden.uplc
@@ -1,0 +1,71 @@
+(program
+   1.1.0
+   (\d ->
+      case
+        (case (unConstrData d) [(\l r -> r)])
+        [ (\ds
+            ds ->
+             case
+               ds
+               [ (\ds
+                   ds ->
+                    case
+                      ds
+                      [ (\ds
+                          ds ->
+                           case
+                             ds
+                             [ (\ds
+                                 ds ->
+                                  case
+                                    ds
+                                    [ (\ds
+                                        ds ->
+                                         case
+                                           ds
+                                           [ (\ds
+                                               ds ->
+                                                case
+                                                  ds
+                                                  [ (\ds
+                                                      ds ->
+                                                       case
+                                                         ds
+                                                         [ (\ds
+                                                             ds ->
+                                                              case
+                                                                ds
+                                                                [ (\ds
+                                                                    ds ->
+                                                                     case
+                                                                       ds
+                                                                       [ (\ds
+                                                                           ds ->
+                                                                            case
+                                                                              ds
+                                                                              [ (\ds
+                                                                                  ds ->
+                                                                                   case
+                                                                                     ds
+                                                                                     [ (\ds
+                                                                                         ds ->
+                                                                                          case
+                                                                                            ds
+                                                                                            [ (\ds
+                                                                                                ds ->
+                                                                                                 case
+                                                                                                   ds
+                                                                                                   [ (\ds
+                                                                                                       ds ->
+                                                                                                        case
+                                                                                                          ds
+                                                                                                          [ (\ds
+                                                                                                              ds ->
+                                                                                                               addInteger
+                                                                                                                 (unIData
+                                                                                                                    ds)
+                                                                                                                 (addInteger
+                                                                                                                    (unIData
+                                                                                                                       ds)
+                                                                                                                    (unIData
+                                                                                                                       ds))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]))

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richSumA.golden.eval
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richSumA.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   461_432
+Memory:                  2_764
+AST Size:                  132
+Flat Size:                 136
+
+(con integer 20)

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richSumA.golden.pir
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richSumA.golden.pir
@@ -1,0 +1,154 @@
+\(d : data) ->
+  (let
+      b = list data
+    in
+    /\r -> \(p : pair integer b) (f : integer -> b -> r) -> case r p [f])
+    {integer}
+    (unConstrData d)
+    (\(idx : integer)
+      (args : list data) ->
+       case
+         integer
+         idx
+         [ (case
+              integer
+              args
+              [ (\(hd : data) (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [(\(hd : data) (tl : list data) -> unIData hd)]) ])
+         , (case
+              integer
+              args
+              [ (\(hd : data)
+                  (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [ (\(hd : data)
+                         (tl : list data) ->
+                          case
+                            integer
+                            tl
+                            [ (\(hd : data)
+                                (tl : list data) ->
+                                 case
+                                   integer
+                                   tl
+                                   [ (\(hd : data)
+                                       (tl : list data) ->
+                                        case
+                                          integer
+                                          tl
+                                          [ (\(hd : data)
+                                              (tl : list data) ->
+                                               case
+                                                 integer
+                                                 tl
+                                                 [ (\(hd : data)
+                                                     (tl : list data) ->
+                                                      addInteger
+                                                        (unIData hd)
+                                                        (unIData
+                                                           (headList
+                                                              {data}
+                                                              tl))) ]) ]) ]) ]) ]) ])
+         , (case
+              integer
+              args
+              [ (\(hd : data)
+                  (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [ (\(hd : data)
+                         (tl : list data) ->
+                          case
+                            integer
+                            tl
+                            [ (\(hd : data)
+                                (tl : list data) ->
+                                 case
+                                   integer
+                                   tl
+                                   [ (\(hd : data)
+                                       (tl : list data) ->
+                                        case
+                                          integer
+                                          tl
+                                          [ (\(hd : data)
+                                              (tl : list data) ->
+                                               case
+                                                 integer
+                                                 tl
+                                                 [ (\(hd : data)
+                                                     (tl : list data) ->
+                                                      case
+                                                        integer
+                                                        tl
+                                                        [ (\(hd : data)
+                                                            (tl : list data) ->
+                                                             case
+                                                               integer
+                                                               tl
+                                                               [ (\(hd : data)
+                                                                   (tl :
+                                                                      list
+                                                                        data) ->
+                                                                    case
+                                                                      integer
+                                                                      tl
+                                                                      [ (\(hd :
+                                                                             data)
+                                                                          (tl :
+                                                                             list
+                                                                               data) ->
+                                                                           case
+                                                                             integer
+                                                                             tl
+                                                                             [ (\(hd :
+                                                                                    data)
+                                                                                 (tl :
+                                                                                    list
+                                                                                      data) ->
+                                                                                  case
+                                                                                    integer
+                                                                                    tl
+                                                                                    [ (\(hd :
+                                                                                           data)
+                                                                                        (tl :
+                                                                                           list
+                                                                                             data) ->
+                                                                                         case
+                                                                                           integer
+                                                                                           tl
+                                                                                           [ (\(hd :
+                                                                                                  data)
+                                                                                               (tl :
+                                                                                                  list
+                                                                                                    data) ->
+                                                                                                case
+                                                                                                  integer
+                                                                                                  tl
+                                                                                                  [ (\(hd :
+                                                                                                         data)
+                                                                                                      (tl :
+                                                                                                         list
+                                                                                                           data) ->
+                                                                                                       case
+                                                                                                         integer
+                                                                                                         tl
+                                                                                                         [ (\(hd :
+                                                                                                                data)
+                                                                                                             (tl :
+                                                                                                                list
+                                                                                                                  data) ->
+                                                                                                              addInteger
+                                                                                                                (unIData
+                                                                                                                   hd)
+                                                                                                                (addInteger
+                                                                                                                   (unIData
+                                                                                                                      hd)
+                                                                                                                   (unIData
+                                                                                                                      hd))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richSumA.golden.uplc
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richSumA.golden.uplc
@@ -1,0 +1,105 @@
+(program
+   1.1.0
+   ((\forced
+      d ->
+       case
+         (unConstrData d)
+         [ (\idx
+             args ->
+              case
+                idx
+                [ (case args [(\hd tl -> case tl [(\hd tl -> unIData hd)])])
+                , (case
+                     args
+                     [ (\hd
+                         tl ->
+                          case
+                            tl
+                            [ (\hd
+                                tl ->
+                                 case
+                                   tl
+                                   [ (\hd
+                                       tl ->
+                                        case
+                                          tl
+                                          [ (\hd
+                                              tl ->
+                                               case
+                                                 tl
+                                                 [ (\hd
+                                                     tl ->
+                                                      case
+                                                        tl
+                                                        [ (\hd
+                                                            tl ->
+                                                             addInteger
+                                                               (unIData hd)
+                                                               (unIData
+                                                                  (forced
+                                                                     tl))) ]) ]) ]) ]) ]) ])
+                , (case
+                     args
+                     [ (\hd
+                         tl ->
+                          case
+                            tl
+                            [ (\hd
+                                tl ->
+                                 case
+                                   tl
+                                   [ (\hd
+                                       tl ->
+                                        case
+                                          tl
+                                          [ (\hd
+                                              tl ->
+                                               case
+                                                 tl
+                                                 [ (\hd
+                                                     tl ->
+                                                      case
+                                                        tl
+                                                        [ (\hd
+                                                            tl ->
+                                                             case
+                                                               tl
+                                                               [ (\hd
+                                                                   tl ->
+                                                                    case
+                                                                      tl
+                                                                      [ (\hd
+                                                                          tl ->
+                                                                           case
+                                                                             tl
+                                                                             [ (\hd
+                                                                                 tl ->
+                                                                                  case
+                                                                                    tl
+                                                                                    [ (\hd
+                                                                                        tl ->
+                                                                                         case
+                                                                                           tl
+                                                                                           [ (\hd
+                                                                                               tl ->
+                                                                                                case
+                                                                                                  tl
+                                                                                                  [ (\hd
+                                                                                                      tl ->
+                                                                                                       case
+                                                                                                         tl
+                                                                                                         [ (\hd
+                                                                                                             tl ->
+                                                                                                              case
+                                                                                                                tl
+                                                                                                                [ (\hd
+                                                                                                                    tl ->
+                                                                                                                     addInteger
+                                                                                                                       (unIData
+                                                                                                                          hd)
+                                                                                                                       (addInteger
+                                                                                                                          (unIData
+                                                                                                                             hd)
+                                                                                                                          (unIData
+                                                                                                                             hd))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])
+      (force headList)))

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richSumB.golden.eval
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richSumB.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_050_534
+Memory:                  5_230
+AST Size:                  132
+Flat Size:                 138
+
+(con integer 100)

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richSumB.golden.pir
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richSumB.golden.pir
@@ -1,0 +1,154 @@
+\(d : data) ->
+  (let
+      b = list data
+    in
+    /\r -> \(p : pair integer b) (f : integer -> b -> r) -> case r p [f])
+    {integer}
+    (unConstrData d)
+    (\(idx : integer)
+      (args : list data) ->
+       case
+         integer
+         idx
+         [ (case
+              integer
+              args
+              [ (\(hd : data) (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [(\(hd : data) (tl : list data) -> unIData hd)]) ])
+         , (case
+              integer
+              args
+              [ (\(hd : data)
+                  (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [ (\(hd : data)
+                         (tl : list data) ->
+                          case
+                            integer
+                            tl
+                            [ (\(hd : data)
+                                (tl : list data) ->
+                                 case
+                                   integer
+                                   tl
+                                   [ (\(hd : data)
+                                       (tl : list data) ->
+                                        case
+                                          integer
+                                          tl
+                                          [ (\(hd : data)
+                                              (tl : list data) ->
+                                               case
+                                                 integer
+                                                 tl
+                                                 [ (\(hd : data)
+                                                     (tl : list data) ->
+                                                      addInteger
+                                                        (unIData hd)
+                                                        (unIData
+                                                           (headList
+                                                              {data}
+                                                              tl))) ]) ]) ]) ]) ]) ])
+         , (case
+              integer
+              args
+              [ (\(hd : data)
+                  (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [ (\(hd : data)
+                         (tl : list data) ->
+                          case
+                            integer
+                            tl
+                            [ (\(hd : data)
+                                (tl : list data) ->
+                                 case
+                                   integer
+                                   tl
+                                   [ (\(hd : data)
+                                       (tl : list data) ->
+                                        case
+                                          integer
+                                          tl
+                                          [ (\(hd : data)
+                                              (tl : list data) ->
+                                               case
+                                                 integer
+                                                 tl
+                                                 [ (\(hd : data)
+                                                     (tl : list data) ->
+                                                      case
+                                                        integer
+                                                        tl
+                                                        [ (\(hd : data)
+                                                            (tl : list data) ->
+                                                             case
+                                                               integer
+                                                               tl
+                                                               [ (\(hd : data)
+                                                                   (tl :
+                                                                      list
+                                                                        data) ->
+                                                                    case
+                                                                      integer
+                                                                      tl
+                                                                      [ (\(hd :
+                                                                             data)
+                                                                          (tl :
+                                                                             list
+                                                                               data) ->
+                                                                           case
+                                                                             integer
+                                                                             tl
+                                                                             [ (\(hd :
+                                                                                    data)
+                                                                                 (tl :
+                                                                                    list
+                                                                                      data) ->
+                                                                                  case
+                                                                                    integer
+                                                                                    tl
+                                                                                    [ (\(hd :
+                                                                                           data)
+                                                                                        (tl :
+                                                                                           list
+                                                                                             data) ->
+                                                                                         case
+                                                                                           integer
+                                                                                           tl
+                                                                                           [ (\(hd :
+                                                                                                  data)
+                                                                                               (tl :
+                                                                                                  list
+                                                                                                    data) ->
+                                                                                                case
+                                                                                                  integer
+                                                                                                  tl
+                                                                                                  [ (\(hd :
+                                                                                                         data)
+                                                                                                      (tl :
+                                                                                                         list
+                                                                                                           data) ->
+                                                                                                       case
+                                                                                                         integer
+                                                                                                         tl
+                                                                                                         [ (\(hd :
+                                                                                                                data)
+                                                                                                             (tl :
+                                                                                                                list
+                                                                                                                  data) ->
+                                                                                                              addInteger
+                                                                                                                (unIData
+                                                                                                                   hd)
+                                                                                                                (addInteger
+                                                                                                                   (unIData
+                                                                                                                      hd)
+                                                                                                                   (unIData
+                                                                                                                      hd))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richSumB.golden.uplc
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richSumB.golden.uplc
@@ -1,0 +1,105 @@
+(program
+   1.1.0
+   ((\forced
+      d ->
+       case
+         (unConstrData d)
+         [ (\idx
+             args ->
+              case
+                idx
+                [ (case args [(\hd tl -> case tl [(\hd tl -> unIData hd)])])
+                , (case
+                     args
+                     [ (\hd
+                         tl ->
+                          case
+                            tl
+                            [ (\hd
+                                tl ->
+                                 case
+                                   tl
+                                   [ (\hd
+                                       tl ->
+                                        case
+                                          tl
+                                          [ (\hd
+                                              tl ->
+                                               case
+                                                 tl
+                                                 [ (\hd
+                                                     tl ->
+                                                      case
+                                                        tl
+                                                        [ (\hd
+                                                            tl ->
+                                                             addInteger
+                                                               (unIData hd)
+                                                               (unIData
+                                                                  (forced
+                                                                     tl))) ]) ]) ]) ]) ]) ])
+                , (case
+                     args
+                     [ (\hd
+                         tl ->
+                          case
+                            tl
+                            [ (\hd
+                                tl ->
+                                 case
+                                   tl
+                                   [ (\hd
+                                       tl ->
+                                        case
+                                          tl
+                                          [ (\hd
+                                              tl ->
+                                               case
+                                                 tl
+                                                 [ (\hd
+                                                     tl ->
+                                                      case
+                                                        tl
+                                                        [ (\hd
+                                                            tl ->
+                                                             case
+                                                               tl
+                                                               [ (\hd
+                                                                   tl ->
+                                                                    case
+                                                                      tl
+                                                                      [ (\hd
+                                                                          tl ->
+                                                                           case
+                                                                             tl
+                                                                             [ (\hd
+                                                                                 tl ->
+                                                                                  case
+                                                                                    tl
+                                                                                    [ (\hd
+                                                                                        tl ->
+                                                                                         case
+                                                                                           tl
+                                                                                           [ (\hd
+                                                                                               tl ->
+                                                                                                case
+                                                                                                  tl
+                                                                                                  [ (\hd
+                                                                                                      tl ->
+                                                                                                       case
+                                                                                                         tl
+                                                                                                         [ (\hd
+                                                                                                             tl ->
+                                                                                                              case
+                                                                                                                tl
+                                                                                                                [ (\hd
+                                                                                                                    tl ->
+                                                                                                                     addInteger
+                                                                                                                       (unIData
+                                                                                                                          hd)
+                                                                                                                       (addInteger
+                                                                                                                          (unIData
+                                                                                                                             hd)
+                                                                                                                          (unIData
+                                                                                                                             hd))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])
+      (force headList)))

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richSumC.golden.eval
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richSumC.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_665_336
+Memory:                  8_832
+AST Size:                  132
+Flat Size:                 156
+
+(con integer 270)

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richSumC.golden.pir
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richSumC.golden.pir
@@ -1,0 +1,154 @@
+\(d : data) ->
+  (let
+      b = list data
+    in
+    /\r -> \(p : pair integer b) (f : integer -> b -> r) -> case r p [f])
+    {integer}
+    (unConstrData d)
+    (\(idx : integer)
+      (args : list data) ->
+       case
+         integer
+         idx
+         [ (case
+              integer
+              args
+              [ (\(hd : data) (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [(\(hd : data) (tl : list data) -> unIData hd)]) ])
+         , (case
+              integer
+              args
+              [ (\(hd : data)
+                  (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [ (\(hd : data)
+                         (tl : list data) ->
+                          case
+                            integer
+                            tl
+                            [ (\(hd : data)
+                                (tl : list data) ->
+                                 case
+                                   integer
+                                   tl
+                                   [ (\(hd : data)
+                                       (tl : list data) ->
+                                        case
+                                          integer
+                                          tl
+                                          [ (\(hd : data)
+                                              (tl : list data) ->
+                                               case
+                                                 integer
+                                                 tl
+                                                 [ (\(hd : data)
+                                                     (tl : list data) ->
+                                                      addInteger
+                                                        (unIData hd)
+                                                        (unIData
+                                                           (headList
+                                                              {data}
+                                                              tl))) ]) ]) ]) ]) ]) ])
+         , (case
+              integer
+              args
+              [ (\(hd : data)
+                  (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [ (\(hd : data)
+                         (tl : list data) ->
+                          case
+                            integer
+                            tl
+                            [ (\(hd : data)
+                                (tl : list data) ->
+                                 case
+                                   integer
+                                   tl
+                                   [ (\(hd : data)
+                                       (tl : list data) ->
+                                        case
+                                          integer
+                                          tl
+                                          [ (\(hd : data)
+                                              (tl : list data) ->
+                                               case
+                                                 integer
+                                                 tl
+                                                 [ (\(hd : data)
+                                                     (tl : list data) ->
+                                                      case
+                                                        integer
+                                                        tl
+                                                        [ (\(hd : data)
+                                                            (tl : list data) ->
+                                                             case
+                                                               integer
+                                                               tl
+                                                               [ (\(hd : data)
+                                                                   (tl :
+                                                                      list
+                                                                        data) ->
+                                                                    case
+                                                                      integer
+                                                                      tl
+                                                                      [ (\(hd :
+                                                                             data)
+                                                                          (tl :
+                                                                             list
+                                                                               data) ->
+                                                                           case
+                                                                             integer
+                                                                             tl
+                                                                             [ (\(hd :
+                                                                                    data)
+                                                                                 (tl :
+                                                                                    list
+                                                                                      data) ->
+                                                                                  case
+                                                                                    integer
+                                                                                    tl
+                                                                                    [ (\(hd :
+                                                                                           data)
+                                                                                        (tl :
+                                                                                           list
+                                                                                             data) ->
+                                                                                         case
+                                                                                           integer
+                                                                                           tl
+                                                                                           [ (\(hd :
+                                                                                                  data)
+                                                                                               (tl :
+                                                                                                  list
+                                                                                                    data) ->
+                                                                                                case
+                                                                                                  integer
+                                                                                                  tl
+                                                                                                  [ (\(hd :
+                                                                                                         data)
+                                                                                                      (tl :
+                                                                                                         list
+                                                                                                           data) ->
+                                                                                                       case
+                                                                                                         integer
+                                                                                                         tl
+                                                                                                         [ (\(hd :
+                                                                                                                data)
+                                                                                                             (tl :
+                                                                                                                list
+                                                                                                                  data) ->
+                                                                                                              addInteger
+                                                                                                                (unIData
+                                                                                                                   hd)
+                                                                                                                (addInteger
+                                                                                                                   (unIData
+                                                                                                                      hd)
+                                                                                                                   (unIData
+                                                                                                                      hd))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])

--- a/plutus-tx-plugin/test/AsData/Budget/9.12/richSumC.golden.uplc
+++ b/plutus-tx-plugin/test/AsData/Budget/9.12/richSumC.golden.uplc
@@ -1,0 +1,105 @@
+(program
+   1.1.0
+   ((\forced
+      d ->
+       case
+         (unConstrData d)
+         [ (\idx
+             args ->
+              case
+                idx
+                [ (case args [(\hd tl -> case tl [(\hd tl -> unIData hd)])])
+                , (case
+                     args
+                     [ (\hd
+                         tl ->
+                          case
+                            tl
+                            [ (\hd
+                                tl ->
+                                 case
+                                   tl
+                                   [ (\hd
+                                       tl ->
+                                        case
+                                          tl
+                                          [ (\hd
+                                              tl ->
+                                               case
+                                                 tl
+                                                 [ (\hd
+                                                     tl ->
+                                                      case
+                                                        tl
+                                                        [ (\hd
+                                                            tl ->
+                                                             addInteger
+                                                               (unIData hd)
+                                                               (unIData
+                                                                  (forced
+                                                                     tl))) ]) ]) ]) ]) ]) ])
+                , (case
+                     args
+                     [ (\hd
+                         tl ->
+                          case
+                            tl
+                            [ (\hd
+                                tl ->
+                                 case
+                                   tl
+                                   [ (\hd
+                                       tl ->
+                                        case
+                                          tl
+                                          [ (\hd
+                                              tl ->
+                                               case
+                                                 tl
+                                                 [ (\hd
+                                                     tl ->
+                                                      case
+                                                        tl
+                                                        [ (\hd
+                                                            tl ->
+                                                             case
+                                                               tl
+                                                               [ (\hd
+                                                                   tl ->
+                                                                    case
+                                                                      tl
+                                                                      [ (\hd
+                                                                          tl ->
+                                                                           case
+                                                                             tl
+                                                                             [ (\hd
+                                                                                 tl ->
+                                                                                  case
+                                                                                    tl
+                                                                                    [ (\hd
+                                                                                        tl ->
+                                                                                         case
+                                                                                           tl
+                                                                                           [ (\hd
+                                                                                               tl ->
+                                                                                                case
+                                                                                                  tl
+                                                                                                  [ (\hd
+                                                                                                      tl ->
+                                                                                                       case
+                                                                                                         tl
+                                                                                                         [ (\hd
+                                                                                                             tl ->
+                                                                                                              case
+                                                                                                                tl
+                                                                                                                [ (\hd
+                                                                                                                    tl ->
+                                                                                                                     addInteger
+                                                                                                                       (unIData
+                                                                                                                          hd)
+                                                                                                                       (addInteger
+                                                                                                                          (unIData
+                                                                                                                             hd)
+                                                                                                                          (unIData
+                                                                                                                             hd))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])
+      (force headList)))

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richInts1.golden.eval
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richInts1.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_376_582
+Memory:                  7_996
+AST Size:                   78
+Flat Size:                  93
+
+(con integer 16)

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richInts1.golden.pir
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richInts1.golden.pir
@@ -1,0 +1,107 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+in
+\(d : data) ->
+  case
+    integer
+    ((let
+         b = list data
+       in
+       \(x : pair integer b) -> case b x [(\(l : integer) (r : b) -> r)])
+       (unConstrData d))
+    [ (\(ds : data)
+        (ds : list data) ->
+         case
+           integer
+           ds
+           [ (\(ds : data)
+               (ds : list data) ->
+                case
+                  integer
+                  ds
+                  [ (\(ds : data)
+                      (ds : list data) ->
+                       case
+                         integer
+                         ds
+                         [ (\(ds : data)
+                             (ds : list data) ->
+                              case
+                                integer
+                                ds
+                                [ (\(ds : data)
+                                    (ds : list data) ->
+                                     case
+                                       integer
+                                       ds
+                                       [ (\(ds : data)
+                                           (ds : list data) ->
+                                            case
+                                              integer
+                                              ds
+                                              [ (\(ds : data)
+                                                  (ds : list data) ->
+                                                   case
+                                                     integer
+                                                     ds
+                                                     [ (\(ds : data)
+                                                         (ds : list data) ->
+                                                          case
+                                                            integer
+                                                            ds
+                                                            [ (\(ds : data)
+                                                                (ds :
+                                                                   list data) ->
+                                                                 case
+                                                                   integer
+                                                                   ds
+                                                                   [ (\(ds :
+                                                                          data)
+                                                                       (ds :
+                                                                          list
+                                                                            data) ->
+                                                                        case
+                                                                          integer
+                                                                          ds
+                                                                          [ (\(ds :
+                                                                                 data)
+                                                                              (ds :
+                                                                                 list
+                                                                                   data) ->
+                                                                               case
+                                                                                 integer
+                                                                                 ds
+                                                                                 [ (\(ds :
+                                                                                        data)
+                                                                                     (ds :
+                                                                                        list
+                                                                                          data) ->
+                                                                                      case
+                                                                                        integer
+                                                                                        ds
+                                                                                        [ (\(ds :
+                                                                                               data)
+                                                                                            (ds :
+                                                                                               list
+                                                                                                 data) ->
+                                                                                             case
+                                                                                               integer
+                                                                                               ds
+                                                                                               [ (\(ds :
+                                                                                                      data)
+                                                                                                   (ds :
+                                                                                                      list
+                                                                                                        data) ->
+                                                                                                    case
+                                                                                                      integer
+                                                                                                      ds
+                                                                                                      [ (\(ds :
+                                                                                                             data)
+                                                                                                          (ds :
+                                                                                                             list
+                                                                                                               data) ->
+                                                                                                           unIData
+                                                                                                             (headList
+                                                                                                                {data}
+                                                                                                                ds)) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richInts1.golden.uplc
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richInts1.golden.uplc
@@ -1,0 +1,68 @@
+(program
+   1.1.0
+   ((\forced
+      d ->
+       case
+         (case (unConstrData d) [(\l r -> r)])
+         [ (\ds
+             ds ->
+              case
+                ds
+                [ (\ds
+                    ds ->
+                     case
+                       ds
+                       [ (\ds
+                           ds ->
+                            case
+                              ds
+                              [ (\ds
+                                  ds ->
+                                   case
+                                     ds
+                                     [ (\ds
+                                         ds ->
+                                          case
+                                            ds
+                                            [ (\ds
+                                                ds ->
+                                                 case
+                                                   ds
+                                                   [ (\ds
+                                                       ds ->
+                                                        case
+                                                          ds
+                                                          [ (\ds
+                                                              ds ->
+                                                               case
+                                                                 ds
+                                                                 [ (\ds
+                                                                     ds ->
+                                                                      case
+                                                                        ds
+                                                                        [ (\ds
+                                                                            ds ->
+                                                                             case
+                                                                               ds
+                                                                               [ (\ds
+                                                                                   ds ->
+                                                                                    case
+                                                                                      ds
+                                                                                      [ (\ds
+                                                                                          ds ->
+                                                                                           case
+                                                                                             ds
+                                                                                             [ (\ds
+                                                                                                 ds ->
+                                                                                                  case
+                                                                                                    ds
+                                                                                                    [ (\ds
+                                                                                                        ds ->
+                                                                                                         case
+                                                                                                           ds
+                                                                                                           [ (\ds
+                                                                                                               ds ->
+                                                                                                                unIData
+                                                                                                                  (forced
+                                                                                                                     ds)) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])
+      (force headList)))

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richInts2.golden.eval
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richInts2.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_351_384
+Memory:                  7_598
+AST Size:                   74
+Flat Size:                  91
+
+(con integer 23)

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richInts2.golden.pir
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richInts2.golden.pir
@@ -1,0 +1,100 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+in
+\(d : data) ->
+  case
+    integer
+    ((let
+         b = list data
+       in
+       \(x : pair integer b) -> case b x [(\(l : integer) (r : b) -> r)])
+       (unConstrData d))
+    [ (\(ds : data)
+        (ds : list data) ->
+         case
+           integer
+           ds
+           [ (\(ds : data)
+               (ds : list data) ->
+                case
+                  integer
+                  ds
+                  [ (\(ds : data)
+                      (ds : list data) ->
+                       case
+                         integer
+                         ds
+                         [ (\(ds : data)
+                             (ds : list data) ->
+                              case
+                                integer
+                                ds
+                                [ (\(ds : data)
+                                    (ds : list data) ->
+                                     case
+                                       integer
+                                       ds
+                                       [ (\(ds : data)
+                                           (ds : list data) ->
+                                            case
+                                              integer
+                                              ds
+                                              [ (\(ds : data)
+                                                  (ds : list data) ->
+                                                   case
+                                                     integer
+                                                     ds
+                                                     [ (\(ds : data)
+                                                         (ds : list data) ->
+                                                          case
+                                                            integer
+                                                            ds
+                                                            [ (\(ds : data)
+                                                                (ds :
+                                                                   list data) ->
+                                                                 case
+                                                                   integer
+                                                                   ds
+                                                                   [ (\(ds :
+                                                                          data)
+                                                                       (ds :
+                                                                          list
+                                                                            data) ->
+                                                                        case
+                                                                          integer
+                                                                          ds
+                                                                          [ (\(ds :
+                                                                                 data)
+                                                                              (ds :
+                                                                                 list
+                                                                                   data) ->
+                                                                               case
+                                                                                 integer
+                                                                                 ds
+                                                                                 [ (\(ds :
+                                                                                        data)
+                                                                                     (ds :
+                                                                                        list
+                                                                                          data) ->
+                                                                                      case
+                                                                                        integer
+                                                                                        ds
+                                                                                        [ (\(ds :
+                                                                                               data)
+                                                                                            (ds :
+                                                                                               list
+                                                                                                 data) ->
+                                                                                             case
+                                                                                               integer
+                                                                                               ds
+                                                                                               [ (\(ds :
+                                                                                                      data)
+                                                                                                   (ds :
+                                                                                                      list
+                                                                                                        data) ->
+                                                                                                    addInteger
+                                                                                                      (unIData
+                                                                                                         ds)
+                                                                                                      (unIData
+                                                                                                         ds)) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richInts2.golden.uplc
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richInts2.golden.uplc
@@ -1,0 +1,64 @@
+(program
+   1.1.0
+   (\d ->
+      case
+        (case (unConstrData d) [(\l r -> r)])
+        [ (\ds
+            ds ->
+             case
+               ds
+               [ (\ds
+                   ds ->
+                    case
+                      ds
+                      [ (\ds
+                          ds ->
+                           case
+                             ds
+                             [ (\ds
+                                 ds ->
+                                  case
+                                    ds
+                                    [ (\ds
+                                        ds ->
+                                         case
+                                           ds
+                                           [ (\ds
+                                               ds ->
+                                                case
+                                                  ds
+                                                  [ (\ds
+                                                      ds ->
+                                                       case
+                                                         ds
+                                                         [ (\ds
+                                                             ds ->
+                                                              case
+                                                                ds
+                                                                [ (\ds
+                                                                    ds ->
+                                                                     case
+                                                                       ds
+                                                                       [ (\ds
+                                                                           ds ->
+                                                                            case
+                                                                              ds
+                                                                              [ (\ds
+                                                                                  ds ->
+                                                                                   case
+                                                                                     ds
+                                                                                     [ (\ds
+                                                                                         ds ->
+                                                                                          case
+                                                                                            ds
+                                                                                            [ (\ds
+                                                                                                ds ->
+                                                                                                 case
+                                                                                                   ds
+                                                                                                   [ (\ds
+                                                                                                       ds ->
+                                                                                                        addInteger
+                                                                                                          (unIData
+                                                                                                             ds)
+                                                                                                          (unIData
+                                                                                                             ds)) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]))

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richInts3.golden.eval
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richInts3.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_633_336
+Memory:                  8_632
+AST Size:                   84
+Flat Size:                 100
+
+(con integer 27)

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richInts3.golden.pir
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richInts3.golden.pir
@@ -1,0 +1,111 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+in
+\(d : data) ->
+  case
+    integer
+    ((let
+         b = list data
+       in
+       \(x : pair integer b) -> case b x [(\(l : integer) (r : b) -> r)])
+       (unConstrData d))
+    [ (\(ds : data)
+        (ds : list data) ->
+         case
+           integer
+           ds
+           [ (\(ds : data)
+               (ds : list data) ->
+                case
+                  integer
+                  ds
+                  [ (\(ds : data)
+                      (ds : list data) ->
+                       case
+                         integer
+                         ds
+                         [ (\(ds : data)
+                             (ds : list data) ->
+                              case
+                                integer
+                                ds
+                                [ (\(ds : data)
+                                    (ds : list data) ->
+                                     case
+                                       integer
+                                       ds
+                                       [ (\(ds : data)
+                                           (ds : list data) ->
+                                            case
+                                              integer
+                                              ds
+                                              [ (\(ds : data)
+                                                  (ds : list data) ->
+                                                   case
+                                                     integer
+                                                     ds
+                                                     [ (\(ds : data)
+                                                         (ds : list data) ->
+                                                          case
+                                                            integer
+                                                            ds
+                                                            [ (\(ds : data)
+                                                                (ds :
+                                                                   list data) ->
+                                                                 case
+                                                                   integer
+                                                                   ds
+                                                                   [ (\(ds :
+                                                                          data)
+                                                                       (ds :
+                                                                          list
+                                                                            data) ->
+                                                                        case
+                                                                          integer
+                                                                          ds
+                                                                          [ (\(ds :
+                                                                                 data)
+                                                                              (ds :
+                                                                                 list
+                                                                                   data) ->
+                                                                               case
+                                                                                 integer
+                                                                                 ds
+                                                                                 [ (\(ds :
+                                                                                        data)
+                                                                                     (ds :
+                                                                                        list
+                                                                                          data) ->
+                                                                                      case
+                                                                                        integer
+                                                                                        ds
+                                                                                        [ (\(ds :
+                                                                                               data)
+                                                                                            (ds :
+                                                                                               list
+                                                                                                 data) ->
+                                                                                             case
+                                                                                               integer
+                                                                                               ds
+                                                                                               [ (\(ds :
+                                                                                                      data)
+                                                                                                   (ds :
+                                                                                                      list
+                                                                                                        data) ->
+                                                                                                    case
+                                                                                                      integer
+                                                                                                      ds
+                                                                                                      [ (\(ds :
+                                                                                                             data)
+                                                                                                          (ds :
+                                                                                                             list
+                                                                                                               data) ->
+                                                                                                           addInteger
+                                                                                                             (unIData
+                                                                                                                ds)
+                                                                                                             (addInteger
+                                                                                                                (unIData
+                                                                                                                   ds)
+                                                                                                                (unIData
+                                                                                                                   ds))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richInts3.golden.uplc
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richInts3.golden.uplc
@@ -1,0 +1,71 @@
+(program
+   1.1.0
+   (\d ->
+      case
+        (case (unConstrData d) [(\l r -> r)])
+        [ (\ds
+            ds ->
+             case
+               ds
+               [ (\ds
+                   ds ->
+                    case
+                      ds
+                      [ (\ds
+                          ds ->
+                           case
+                             ds
+                             [ (\ds
+                                 ds ->
+                                  case
+                                    ds
+                                    [ (\ds
+                                        ds ->
+                                         case
+                                           ds
+                                           [ (\ds
+                                               ds ->
+                                                case
+                                                  ds
+                                                  [ (\ds
+                                                      ds ->
+                                                       case
+                                                         ds
+                                                         [ (\ds
+                                                             ds ->
+                                                              case
+                                                                ds
+                                                                [ (\ds
+                                                                    ds ->
+                                                                     case
+                                                                       ds
+                                                                       [ (\ds
+                                                                           ds ->
+                                                                            case
+                                                                              ds
+                                                                              [ (\ds
+                                                                                  ds ->
+                                                                                   case
+                                                                                     ds
+                                                                                     [ (\ds
+                                                                                         ds ->
+                                                                                          case
+                                                                                            ds
+                                                                                            [ (\ds
+                                                                                                ds ->
+                                                                                                 case
+                                                                                                   ds
+                                                                                                   [ (\ds
+                                                                                                       ds ->
+                                                                                                        case
+                                                                                                          ds
+                                                                                                          [ (\ds
+                                                                                                              ds ->
+                                                                                                               addInteger
+                                                                                                                 (unIData
+                                                                                                                    ds)
+                                                                                                                 (addInteger
+                                                                                                                    (unIData
+                                                                                                                       ds)
+                                                                                                                    (unIData
+                                                                                                                       ds))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]))

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richSumA.golden.eval
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richSumA.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   461_432
+Memory:                  2_764
+AST Size:                  132
+Flat Size:                 136
+
+(con integer 20)

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richSumA.golden.pir
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richSumA.golden.pir
@@ -1,0 +1,154 @@
+\(d : data) ->
+  (let
+      b = list data
+    in
+    /\r -> \(p : pair integer b) (f : integer -> b -> r) -> case r p [f])
+    {integer}
+    (unConstrData d)
+    (\(idx : integer)
+      (args : list data) ->
+       case
+         integer
+         idx
+         [ (case
+              integer
+              args
+              [ (\(hd : data) (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [(\(hd : data) (tl : list data) -> unIData hd)]) ])
+         , (case
+              integer
+              args
+              [ (\(hd : data)
+                  (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [ (\(hd : data)
+                         (tl : list data) ->
+                          case
+                            integer
+                            tl
+                            [ (\(hd : data)
+                                (tl : list data) ->
+                                 case
+                                   integer
+                                   tl
+                                   [ (\(hd : data)
+                                       (tl : list data) ->
+                                        case
+                                          integer
+                                          tl
+                                          [ (\(hd : data)
+                                              (tl : list data) ->
+                                               case
+                                                 integer
+                                                 tl
+                                                 [ (\(hd : data)
+                                                     (tl : list data) ->
+                                                      addInteger
+                                                        (unIData hd)
+                                                        (unIData
+                                                           (headList
+                                                              {data}
+                                                              tl))) ]) ]) ]) ]) ]) ])
+         , (case
+              integer
+              args
+              [ (\(hd : data)
+                  (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [ (\(hd : data)
+                         (tl : list data) ->
+                          case
+                            integer
+                            tl
+                            [ (\(hd : data)
+                                (tl : list data) ->
+                                 case
+                                   integer
+                                   tl
+                                   [ (\(hd : data)
+                                       (tl : list data) ->
+                                        case
+                                          integer
+                                          tl
+                                          [ (\(hd : data)
+                                              (tl : list data) ->
+                                               case
+                                                 integer
+                                                 tl
+                                                 [ (\(hd : data)
+                                                     (tl : list data) ->
+                                                      case
+                                                        integer
+                                                        tl
+                                                        [ (\(hd : data)
+                                                            (tl : list data) ->
+                                                             case
+                                                               integer
+                                                               tl
+                                                               [ (\(hd : data)
+                                                                   (tl :
+                                                                      list
+                                                                        data) ->
+                                                                    case
+                                                                      integer
+                                                                      tl
+                                                                      [ (\(hd :
+                                                                             data)
+                                                                          (tl :
+                                                                             list
+                                                                               data) ->
+                                                                           case
+                                                                             integer
+                                                                             tl
+                                                                             [ (\(hd :
+                                                                                    data)
+                                                                                 (tl :
+                                                                                    list
+                                                                                      data) ->
+                                                                                  case
+                                                                                    integer
+                                                                                    tl
+                                                                                    [ (\(hd :
+                                                                                           data)
+                                                                                        (tl :
+                                                                                           list
+                                                                                             data) ->
+                                                                                         case
+                                                                                           integer
+                                                                                           tl
+                                                                                           [ (\(hd :
+                                                                                                  data)
+                                                                                               (tl :
+                                                                                                  list
+                                                                                                    data) ->
+                                                                                                case
+                                                                                                  integer
+                                                                                                  tl
+                                                                                                  [ (\(hd :
+                                                                                                         data)
+                                                                                                      (tl :
+                                                                                                         list
+                                                                                                           data) ->
+                                                                                                       case
+                                                                                                         integer
+                                                                                                         tl
+                                                                                                         [ (\(hd :
+                                                                                                                data)
+                                                                                                             (tl :
+                                                                                                                list
+                                                                                                                  data) ->
+                                                                                                              addInteger
+                                                                                                                (unIData
+                                                                                                                   hd)
+                                                                                                                (addInteger
+                                                                                                                   (unIData
+                                                                                                                      hd)
+                                                                                                                   (unIData
+                                                                                                                      hd))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richSumA.golden.uplc
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richSumA.golden.uplc
@@ -1,0 +1,105 @@
+(program
+   1.1.0
+   ((\forced
+      d ->
+       case
+         (unConstrData d)
+         [ (\idx
+             args ->
+              case
+                idx
+                [ (case args [(\hd tl -> case tl [(\hd tl -> unIData hd)])])
+                , (case
+                     args
+                     [ (\hd
+                         tl ->
+                          case
+                            tl
+                            [ (\hd
+                                tl ->
+                                 case
+                                   tl
+                                   [ (\hd
+                                       tl ->
+                                        case
+                                          tl
+                                          [ (\hd
+                                              tl ->
+                                               case
+                                                 tl
+                                                 [ (\hd
+                                                     tl ->
+                                                      case
+                                                        tl
+                                                        [ (\hd
+                                                            tl ->
+                                                             addInteger
+                                                               (unIData hd)
+                                                               (unIData
+                                                                  (forced
+                                                                     tl))) ]) ]) ]) ]) ]) ])
+                , (case
+                     args
+                     [ (\hd
+                         tl ->
+                          case
+                            tl
+                            [ (\hd
+                                tl ->
+                                 case
+                                   tl
+                                   [ (\hd
+                                       tl ->
+                                        case
+                                          tl
+                                          [ (\hd
+                                              tl ->
+                                               case
+                                                 tl
+                                                 [ (\hd
+                                                     tl ->
+                                                      case
+                                                        tl
+                                                        [ (\hd
+                                                            tl ->
+                                                             case
+                                                               tl
+                                                               [ (\hd
+                                                                   tl ->
+                                                                    case
+                                                                      tl
+                                                                      [ (\hd
+                                                                          tl ->
+                                                                           case
+                                                                             tl
+                                                                             [ (\hd
+                                                                                 tl ->
+                                                                                  case
+                                                                                    tl
+                                                                                    [ (\hd
+                                                                                        tl ->
+                                                                                         case
+                                                                                           tl
+                                                                                           [ (\hd
+                                                                                               tl ->
+                                                                                                case
+                                                                                                  tl
+                                                                                                  [ (\hd
+                                                                                                      tl ->
+                                                                                                       case
+                                                                                                         tl
+                                                                                                         [ (\hd
+                                                                                                             tl ->
+                                                                                                              case
+                                                                                                                tl
+                                                                                                                [ (\hd
+                                                                                                                    tl ->
+                                                                                                                     addInteger
+                                                                                                                       (unIData
+                                                                                                                          hd)
+                                                                                                                       (addInteger
+                                                                                                                          (unIData
+                                                                                                                             hd)
+                                                                                                                          (unIData
+                                                                                                                             hd))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])
+      (force headList)))

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richSumB.golden.eval
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richSumB.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_050_534
+Memory:                  5_230
+AST Size:                  132
+Flat Size:                 138
+
+(con integer 100)

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richSumB.golden.pir
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richSumB.golden.pir
@@ -1,0 +1,154 @@
+\(d : data) ->
+  (let
+      b = list data
+    in
+    /\r -> \(p : pair integer b) (f : integer -> b -> r) -> case r p [f])
+    {integer}
+    (unConstrData d)
+    (\(idx : integer)
+      (args : list data) ->
+       case
+         integer
+         idx
+         [ (case
+              integer
+              args
+              [ (\(hd : data) (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [(\(hd : data) (tl : list data) -> unIData hd)]) ])
+         , (case
+              integer
+              args
+              [ (\(hd : data)
+                  (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [ (\(hd : data)
+                         (tl : list data) ->
+                          case
+                            integer
+                            tl
+                            [ (\(hd : data)
+                                (tl : list data) ->
+                                 case
+                                   integer
+                                   tl
+                                   [ (\(hd : data)
+                                       (tl : list data) ->
+                                        case
+                                          integer
+                                          tl
+                                          [ (\(hd : data)
+                                              (tl : list data) ->
+                                               case
+                                                 integer
+                                                 tl
+                                                 [ (\(hd : data)
+                                                     (tl : list data) ->
+                                                      addInteger
+                                                        (unIData hd)
+                                                        (unIData
+                                                           (headList
+                                                              {data}
+                                                              tl))) ]) ]) ]) ]) ]) ])
+         , (case
+              integer
+              args
+              [ (\(hd : data)
+                  (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [ (\(hd : data)
+                         (tl : list data) ->
+                          case
+                            integer
+                            tl
+                            [ (\(hd : data)
+                                (tl : list data) ->
+                                 case
+                                   integer
+                                   tl
+                                   [ (\(hd : data)
+                                       (tl : list data) ->
+                                        case
+                                          integer
+                                          tl
+                                          [ (\(hd : data)
+                                              (tl : list data) ->
+                                               case
+                                                 integer
+                                                 tl
+                                                 [ (\(hd : data)
+                                                     (tl : list data) ->
+                                                      case
+                                                        integer
+                                                        tl
+                                                        [ (\(hd : data)
+                                                            (tl : list data) ->
+                                                             case
+                                                               integer
+                                                               tl
+                                                               [ (\(hd : data)
+                                                                   (tl :
+                                                                      list
+                                                                        data) ->
+                                                                    case
+                                                                      integer
+                                                                      tl
+                                                                      [ (\(hd :
+                                                                             data)
+                                                                          (tl :
+                                                                             list
+                                                                               data) ->
+                                                                           case
+                                                                             integer
+                                                                             tl
+                                                                             [ (\(hd :
+                                                                                    data)
+                                                                                 (tl :
+                                                                                    list
+                                                                                      data) ->
+                                                                                  case
+                                                                                    integer
+                                                                                    tl
+                                                                                    [ (\(hd :
+                                                                                           data)
+                                                                                        (tl :
+                                                                                           list
+                                                                                             data) ->
+                                                                                         case
+                                                                                           integer
+                                                                                           tl
+                                                                                           [ (\(hd :
+                                                                                                  data)
+                                                                                               (tl :
+                                                                                                  list
+                                                                                                    data) ->
+                                                                                                case
+                                                                                                  integer
+                                                                                                  tl
+                                                                                                  [ (\(hd :
+                                                                                                         data)
+                                                                                                      (tl :
+                                                                                                         list
+                                                                                                           data) ->
+                                                                                                       case
+                                                                                                         integer
+                                                                                                         tl
+                                                                                                         [ (\(hd :
+                                                                                                                data)
+                                                                                                             (tl :
+                                                                                                                list
+                                                                                                                  data) ->
+                                                                                                              addInteger
+                                                                                                                (unIData
+                                                                                                                   hd)
+                                                                                                                (addInteger
+                                                                                                                   (unIData
+                                                                                                                      hd)
+                                                                                                                   (unIData
+                                                                                                                      hd))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richSumB.golden.uplc
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richSumB.golden.uplc
@@ -1,0 +1,105 @@
+(program
+   1.1.0
+   ((\forced
+      d ->
+       case
+         (unConstrData d)
+         [ (\idx
+             args ->
+              case
+                idx
+                [ (case args [(\hd tl -> case tl [(\hd tl -> unIData hd)])])
+                , (case
+                     args
+                     [ (\hd
+                         tl ->
+                          case
+                            tl
+                            [ (\hd
+                                tl ->
+                                 case
+                                   tl
+                                   [ (\hd
+                                       tl ->
+                                        case
+                                          tl
+                                          [ (\hd
+                                              tl ->
+                                               case
+                                                 tl
+                                                 [ (\hd
+                                                     tl ->
+                                                      case
+                                                        tl
+                                                        [ (\hd
+                                                            tl ->
+                                                             addInteger
+                                                               (unIData hd)
+                                                               (unIData
+                                                                  (forced
+                                                                     tl))) ]) ]) ]) ]) ]) ])
+                , (case
+                     args
+                     [ (\hd
+                         tl ->
+                          case
+                            tl
+                            [ (\hd
+                                tl ->
+                                 case
+                                   tl
+                                   [ (\hd
+                                       tl ->
+                                        case
+                                          tl
+                                          [ (\hd
+                                              tl ->
+                                               case
+                                                 tl
+                                                 [ (\hd
+                                                     tl ->
+                                                      case
+                                                        tl
+                                                        [ (\hd
+                                                            tl ->
+                                                             case
+                                                               tl
+                                                               [ (\hd
+                                                                   tl ->
+                                                                    case
+                                                                      tl
+                                                                      [ (\hd
+                                                                          tl ->
+                                                                           case
+                                                                             tl
+                                                                             [ (\hd
+                                                                                 tl ->
+                                                                                  case
+                                                                                    tl
+                                                                                    [ (\hd
+                                                                                        tl ->
+                                                                                         case
+                                                                                           tl
+                                                                                           [ (\hd
+                                                                                               tl ->
+                                                                                                case
+                                                                                                  tl
+                                                                                                  [ (\hd
+                                                                                                      tl ->
+                                                                                                       case
+                                                                                                         tl
+                                                                                                         [ (\hd
+                                                                                                             tl ->
+                                                                                                              case
+                                                                                                                tl
+                                                                                                                [ (\hd
+                                                                                                                    tl ->
+                                                                                                                     addInteger
+                                                                                                                       (unIData
+                                                                                                                          hd)
+                                                                                                                       (addInteger
+                                                                                                                          (unIData
+                                                                                                                             hd)
+                                                                                                                          (unIData
+                                                                                                                             hd))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])
+      (force headList)))

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richSumC.golden.eval
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richSumC.golden.eval
@@ -1,0 +1,6 @@
+CPU:                 1_665_336
+Memory:                  8_832
+AST Size:                  132
+Flat Size:                 156
+
+(con integer 270)

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richSumC.golden.pir
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richSumC.golden.pir
@@ -1,0 +1,154 @@
+\(d : data) ->
+  (let
+      b = list data
+    in
+    /\r -> \(p : pair integer b) (f : integer -> b -> r) -> case r p [f])
+    {integer}
+    (unConstrData d)
+    (\(idx : integer)
+      (args : list data) ->
+       case
+         integer
+         idx
+         [ (case
+              integer
+              args
+              [ (\(hd : data) (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [(\(hd : data) (tl : list data) -> unIData hd)]) ])
+         , (case
+              integer
+              args
+              [ (\(hd : data)
+                  (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [ (\(hd : data)
+                         (tl : list data) ->
+                          case
+                            integer
+                            tl
+                            [ (\(hd : data)
+                                (tl : list data) ->
+                                 case
+                                   integer
+                                   tl
+                                   [ (\(hd : data)
+                                       (tl : list data) ->
+                                        case
+                                          integer
+                                          tl
+                                          [ (\(hd : data)
+                                              (tl : list data) ->
+                                               case
+                                                 integer
+                                                 tl
+                                                 [ (\(hd : data)
+                                                     (tl : list data) ->
+                                                      addInteger
+                                                        (unIData hd)
+                                                        (unIData
+                                                           (headList
+                                                              {data}
+                                                              tl))) ]) ]) ]) ]) ]) ])
+         , (case
+              integer
+              args
+              [ (\(hd : data)
+                  (tl : list data) ->
+                   case
+                     integer
+                     tl
+                     [ (\(hd : data)
+                         (tl : list data) ->
+                          case
+                            integer
+                            tl
+                            [ (\(hd : data)
+                                (tl : list data) ->
+                                 case
+                                   integer
+                                   tl
+                                   [ (\(hd : data)
+                                       (tl : list data) ->
+                                        case
+                                          integer
+                                          tl
+                                          [ (\(hd : data)
+                                              (tl : list data) ->
+                                               case
+                                                 integer
+                                                 tl
+                                                 [ (\(hd : data)
+                                                     (tl : list data) ->
+                                                      case
+                                                        integer
+                                                        tl
+                                                        [ (\(hd : data)
+                                                            (tl : list data) ->
+                                                             case
+                                                               integer
+                                                               tl
+                                                               [ (\(hd : data)
+                                                                   (tl :
+                                                                      list
+                                                                        data) ->
+                                                                    case
+                                                                      integer
+                                                                      tl
+                                                                      [ (\(hd :
+                                                                             data)
+                                                                          (tl :
+                                                                             list
+                                                                               data) ->
+                                                                           case
+                                                                             integer
+                                                                             tl
+                                                                             [ (\(hd :
+                                                                                    data)
+                                                                                 (tl :
+                                                                                    list
+                                                                                      data) ->
+                                                                                  case
+                                                                                    integer
+                                                                                    tl
+                                                                                    [ (\(hd :
+                                                                                           data)
+                                                                                        (tl :
+                                                                                           list
+                                                                                             data) ->
+                                                                                         case
+                                                                                           integer
+                                                                                           tl
+                                                                                           [ (\(hd :
+                                                                                                  data)
+                                                                                               (tl :
+                                                                                                  list
+                                                                                                    data) ->
+                                                                                                case
+                                                                                                  integer
+                                                                                                  tl
+                                                                                                  [ (\(hd :
+                                                                                                         data)
+                                                                                                      (tl :
+                                                                                                         list
+                                                                                                           data) ->
+                                                                                                       case
+                                                                                                         integer
+                                                                                                         tl
+                                                                                                         [ (\(hd :
+                                                                                                                data)
+                                                                                                             (tl :
+                                                                                                                list
+                                                                                                                  data) ->
+                                                                                                              addInteger
+                                                                                                                (unIData
+                                                                                                                   hd)
+                                                                                                                (addInteger
+                                                                                                                   (unIData
+                                                                                                                      hd)
+                                                                                                                   (unIData
+                                                                                                                      hd))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])

--- a/plutus-tx-plugin/test/AsData/Budget/9.6/richSumC.golden.uplc
+++ b/plutus-tx-plugin/test/AsData/Budget/9.6/richSumC.golden.uplc
@@ -1,0 +1,105 @@
+(program
+   1.1.0
+   ((\forced
+      d ->
+       case
+         (unConstrData d)
+         [ (\idx
+             args ->
+              case
+                idx
+                [ (case args [(\hd tl -> case tl [(\hd tl -> unIData hd)])])
+                , (case
+                     args
+                     [ (\hd
+                         tl ->
+                          case
+                            tl
+                            [ (\hd
+                                tl ->
+                                 case
+                                   tl
+                                   [ (\hd
+                                       tl ->
+                                        case
+                                          tl
+                                          [ (\hd
+                                              tl ->
+                                               case
+                                                 tl
+                                                 [ (\hd
+                                                     tl ->
+                                                      case
+                                                        tl
+                                                        [ (\hd
+                                                            tl ->
+                                                             addInteger
+                                                               (unIData hd)
+                                                               (unIData
+                                                                  (forced
+                                                                     tl))) ]) ]) ]) ]) ]) ])
+                , (case
+                     args
+                     [ (\hd
+                         tl ->
+                          case
+                            tl
+                            [ (\hd
+                                tl ->
+                                 case
+                                   tl
+                                   [ (\hd
+                                       tl ->
+                                        case
+                                          tl
+                                          [ (\hd
+                                              tl ->
+                                               case
+                                                 tl
+                                                 [ (\hd
+                                                     tl ->
+                                                      case
+                                                        tl
+                                                        [ (\hd
+                                                            tl ->
+                                                             case
+                                                               tl
+                                                               [ (\hd
+                                                                   tl ->
+                                                                    case
+                                                                      tl
+                                                                      [ (\hd
+                                                                          tl ->
+                                                                           case
+                                                                             tl
+                                                                             [ (\hd
+                                                                                 tl ->
+                                                                                  case
+                                                                                    tl
+                                                                                    [ (\hd
+                                                                                        tl ->
+                                                                                         case
+                                                                                           tl
+                                                                                           [ (\hd
+                                                                                               tl ->
+                                                                                                case
+                                                                                                  tl
+                                                                                                  [ (\hd
+                                                                                                      tl ->
+                                                                                                       case
+                                                                                                         tl
+                                                                                                         [ (\hd
+                                                                                                             tl ->
+                                                                                                              case
+                                                                                                                tl
+                                                                                                                [ (\hd
+                                                                                                                    tl ->
+                                                                                                                     addInteger
+                                                                                                                       (unIData
+                                                                                                                          hd)
+                                                                                                                       (addInteger
+                                                                                                                          (unIData
+                                                                                                                             hd)
+                                                                                                                          (unIData
+                                                                                                                             hd))) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ]) ])
+      (force headList)))

--- a/plutus-tx-plugin/test/AsData/Budget/Spec.hs
+++ b/plutus-tx-plugin/test/AsData/Budget/Spec.hs
@@ -24,6 +24,9 @@ tests =
           "onlyUseFirstField-manual"
           onlyUseFirstFieldManual
           (onlyUseFirstFieldManual `unsafeApplyCode` inp)
+      , goldenBundle "richInts1" richInts1 (richInts1 `unsafeApplyCode` inpRich)
+      , goldenBundle "richInts2" richInts2 (richInts2 `unsafeApplyCode` inpRich)
+      , goldenBundle "richInts3" richInts3 (richInts3 `unsafeApplyCode` inpRich)
       , goldenBundle "patternMatching" patternMatching (patternMatching `unsafeApplyCode` inp)
       , goldenBundle "recordFields" recordFields (recordFields `unsafeApplyCode` inp)
       , goldenBundle "destructSum" destructSum (destructSum `unsafeApplyCode` inpSum)
@@ -32,9 +35,17 @@ tests =
           destructSumManual
           (destructSumManual `unsafeApplyCode` inpSumM)
       , goldenBundle
-          "richSumSingleField"
-          richSumSingleField
-          (richSumSingleField `unsafeApplyCode` inpRichSum)
+          "richSumA"
+          richSum
+          (richSum `unsafeApplyCode` inpRichSumA)
+      , goldenBundle
+          "richSumB"
+          richSum
+          (richSum `unsafeApplyCode` inpRichSumB)
+      , goldenBundle
+          "richSumC"
+          richSum
+          (richSum `unsafeApplyCode` inpRichSumC)
       ]
 
 -- A function that only accesses the first field of `Ints`.
@@ -50,6 +61,27 @@ onlyUseFirstFieldManual =
   plinthc
     ( \d -> case PlutusTx.unsafeFromBuiltinData d of
         IntsManual {int1Manual = x} -> x
+    )
+
+richInts1 :: CompiledCode (PlutusTx.BuiltinData -> Integer)
+richInts1 =
+  plinthc
+    ( \d -> case PlutusTx.unsafeFromBuiltinData d of
+        RichInts {ri16 = x} -> x
+    )
+
+richInts2 :: CompiledCode (PlutusTx.BuiltinData -> Integer)
+richInts2 =
+  plinthc
+    ( \d -> case PlutusTx.unsafeFromBuiltinData d of
+        RichInts {ri9 = x, ri14 = y} -> PlutusTx.addInteger x y
+    )
+
+richInts3 :: CompiledCode (PlutusTx.BuiltinData -> Integer)
+richInts3 =
+  plinthc
+    ( \d -> case PlutusTx.unsafeFromBuiltinData d of
+        RichInts {ri4 = x, ri8 = y, ri15 = z} -> PlutusTx.addInteger x (PlutusTx.addInteger y z)
     )
 
 patternMatching :: CompiledCode (PlutusTx.BuiltinData -> Integer)
@@ -139,19 +171,22 @@ destructSumManual =
     )
 
 -- Only a small number of fields of a sum type are accessed.
-richSumSingleField :: CompiledCode (PlutusTx.BuiltinData -> Integer)
-richSumSingleField =
+richSum :: CompiledCode (PlutusTx.BuiltinData -> Integer)
+richSum =
   plinthc
-    ( \d ->
+    ( \d0 ->
         matchRichSum
-          (PlutusTx.unsafeFromBuiltinData d)
-          (\a _ _ _ _ _ -> a)
-          (\_ b _ _ _ _ _ -> b)
-          (\_ _ c _ _ _ _ _ -> c)
+          (PlutusTx.unsafeFromBuiltinData d0)
+          (\_ b _ _ _ _ -> b)
+          (\_ _ c _ _ _ g -> PlutusTx.addInteger c g)
+          (\_ _ _ d _ _ _ _ i _ _ _ _ n _ _ -> PlutusTx.addInteger d (PlutusTx.addInteger i n))
     )
 
 inp :: CompiledCode PlutusTx.BuiltinData
 inp = liftCodeDef (PlutusTx.toBuiltinData (Ints 10 20 30 40))
+
+inpRich :: CompiledCode PlutusTx.BuiltinData
+inpRich = liftCodeDef (PlutusTx.toBuiltinData (RichInts 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16))
 
 inpSum :: CompiledCode PlutusTx.BuiltinData
 inpSum = liftCodeDef (PlutusTx.toBuiltinData (TheseD (Ints 10 20 30 40) (Ints 10 20 30 40)))
@@ -159,5 +194,23 @@ inpSum = liftCodeDef (PlutusTx.toBuiltinData (TheseD (Ints 10 20 30 40) (Ints 10
 inpSumM :: CompiledCode PlutusTx.BuiltinData
 inpSumM = liftCodeDef (PlutusTx.toBuiltinData (TheseDManual (Ints 10 20 30 40) (Ints 10 20 30 40)))
 
-inpRichSum :: CompiledCode PlutusTx.BuiltinData
-inpRichSum = liftCodeDef (PlutusTx.toBuiltinData (RichC 10 20 30 40 50 60 70 80))
+inpRichSumA :: CompiledCode PlutusTx.BuiltinData
+inpRichSumA =
+  liftCodeDef
+    ( PlutusTx.toBuiltinData
+        (RichA 10 20 30 40 50 60)
+    )
+
+inpRichSumB :: CompiledCode PlutusTx.BuiltinData
+inpRichSumB =
+  liftCodeDef
+    ( PlutusTx.toBuiltinData
+        (RichB 10 20 30 40 50 60 70)
+    )
+
+inpRichSumC :: CompiledCode PlutusTx.BuiltinData
+inpRichSumC =
+  liftCodeDef
+    ( PlutusTx.toBuiltinData
+        (RichC 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160)
+    )

--- a/plutus-tx-plugin/test/AsData/Budget/Types.hs
+++ b/plutus-tx-plugin/test/AsData/Budget/Types.hs
@@ -70,6 +70,29 @@ pattern IntsManual {int1Manual, int2Manual, int3Manual, int4Manual} <-
 
 AsData.asData
   [d|
+    data RichInts = RichInts
+      { ri1 :: Integer
+      , ri2 :: Integer
+      , ri3 :: Integer
+      , ri4 :: Integer
+      , ri5 :: Integer
+      , ri6 :: Integer
+      , ri7 :: Integer
+      , ri8 :: Integer
+      , ri9 :: Integer
+      , ri10 :: Integer
+      , ri11 :: Integer
+      , ri12 :: Integer
+      , ri13 :: Integer
+      , ri14 :: Integer
+      , ri15 :: Integer
+      , ri16 :: Integer
+      }
+      deriving newtype (PlutusTx.Eq, PlutusTx.FromData, PlutusTx.UnsafeFromData, PlutusTx.ToData)
+    |]
+
+AsData.asData
+  [d|
     data TheseD a b
       = ThisD a
       | ThatD b
@@ -143,6 +166,22 @@ AsData.asData
     data RichSum
       = RichA Integer Integer Integer Integer Integer Integer
       | RichB Integer Integer Integer Integer Integer Integer Integer
-      | RichC Integer Integer Integer Integer Integer Integer Integer Integer
+      | RichC
+          Integer
+          Integer
+          Integer
+          Integer
+          Integer
+          Integer
+          Integer
+          Integer
+          Integer
+          Integer
+          Integer
+          Integer
+          Integer
+          Integer
+          Integer
+          Integer
       deriving newtype (PlutusTx.Eq, PlutusTx.FromData, PlutusTx.UnsafeFromData, PlutusTx.ToData)
     |]

--- a/plutus-tx-plugin/test/AsData/Budget/Types.hs
+++ b/plutus-tx-plugin/test/AsData/Budget/Types.hs
@@ -68,6 +68,8 @@ pattern IntsManual {int1Manual, int2Manual, int3Manual, int4Manual} <-
             )
         )
 
+-- This is for testing that the CollapseCase pass rewrites consecutive unused
+-- casing on lists into `dropList`.
 AsData.asData
   [d|
     data RichInts = RichInts


### PR DESCRIPTION
We should see improvements in these tests once `AsData` starts using `dropList` in the codegen.