### PR TITLE
Remove the `deriving-aeson` dependency

### DIFF
--- a/plutus-core/changelog.d/20260728_100010_yuriy.lazaryev_issue_7870_remove_deriving_aeson.md
+++ b/plutus-core/changelog.d/20260728_100010_yuriy.lazaryev_issue_7870_remove_deriving_aeson.md
@@ -1,0 +1,7 @@
+### Removed
+
+- `LowerInitialCharacter` is no longer exported from `PlutusCore.Evaluation.Machine.ExBudget`; it existed solely to support `deriving-aeson`, which `plutus-core` no longer depends on.
+
+### Changed
+
+- Replaced the `deriving-aeson`-based JSON instances of the cost model types with plain `aeson` generic instances. The JSON format is unchanged.

--- a/plutus-core/cost-model/CostModelGeneration.md
+++ b/plutus-core/cost-model/CostModelGeneration.md
@@ -292,7 +292,7 @@ our case, the costing function is given by the
 type. The type prefix `ModelTwoArguments` is removed from the
 constructor name and the remaining `MinSize` is converted to
 `min_size` by the Aeson library's
-[`CamelToSnake`](https://hackage.haskell.org/package/deriving-aeson-0.2.8/docs/Deriving-Aeson.html#t:CamelToSnake)
+[`camelTo2`](https://hackage.haskell.org/package/aeson/docs/Data-Aeson.html#v:camelTo2)
 transformation.  Similarly, the names of the
 `modelMinSizeIntercept` and `modelMinSizeSlope` fields in the
 `ModelMinSize` type are converted to `slope` and `intercept`.  In

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -382,6 +382,7 @@ test-suite plutus-core-test
     CBOR.DataStability
     Check.Spec
     CostModelInterface.Spec
+    CostModelJSON.Spec
     CostModelSafety.Spec
     Evaluation.Machines
     Evaluation.Spec
@@ -398,6 +399,9 @@ test-suite plutus-core-test
   default-language: Haskell2010
   build-depends:
     , aeson
+    , aeson-diff
+    , aeson-pretty
+    , barbies
     , base                             >=4.9     && <5
     , base16-bytestring                ^>=1.0
     , bytestring

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -327,7 +327,6 @@ library
     , data-default-class
     , deepseq
     , dependent-sum               >=0.7.1.0
-    , deriving-aeson              >=0.2.3
     , deriving-compat
     , dlist
     , exceptions

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs
@@ -1,6 +1,5 @@
 -- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE StrictData #-}
@@ -57,13 +56,12 @@ import PlutusPrelude hiding (toList)
 
 import PlutusCore.Evaluation.Machine.CostingFun.Core
 import PlutusCore.Evaluation.Machine.CostingFun.JSON ()
-import PlutusCore.Evaluation.Machine.ExBudget
 
 import Barbies
 import Data.Aeson
 import Data.Kind qualified as Kind
+import Data.List (stripPrefix)
 import Data.Monoid
-import Deriving.Aeson
 import Language.Haskell.TH.Syntax hiding (Name, newName)
 
 type BuiltinCostModel = BuiltinCostModelBase CostingFun
@@ -203,18 +201,21 @@ data BuiltinCostModelBase f
   deriving stock (Generic)
   deriving anyclass (FunctorB, TraversableB, ConstraintsB)
 
-deriving via
-  CustomJSON
-    '[FieldLabelModifier (StripPrefix "param", LowerInitialCharacter)]
-    (BuiltinCostModelBase CostingFun)
-  instance
-    ToJSON (BuiltinCostModelBase CostingFun)
-deriving via
-  CustomJSON
-    '[FieldLabelModifier (StripPrefix "param", LowerInitialCharacter)]
-    (BuiltinCostModelBase CostingFun)
-  instance
-    FromJSON (BuiltinCostModelBase CostingFun)
+{-| JSON options for 'BuiltinCostModelBase': drop the @param@ prefix and lower the initial
+character, so that the names of the JSON fields are exactly the same as the names of the
+builtins. -}
+builtinCostModelOptions :: Options
+builtinCostModelOptions =
+  defaultOptions {fieldLabelModifier = lowerInitialChar . dropPrefix "param"}
+  where
+    dropPrefix prefix s = fromMaybe s (stripPrefix prefix s)
+
+instance ToJSON (BuiltinCostModelBase CostingFun) where
+  toJSON = genericToJSON builtinCostModelOptions
+  toEncoding = genericToEncoding builtinCostModelOptions
+
+instance FromJSON (BuiltinCostModelBase CostingFun) where
+  parseJSON = genericParseJSON builtinCostModelOptions
 
 {-| Same as 'CostingFun' but maybe missing.
 We could use 'Compose Maybe CostinFun' instead but we would then need an orphan ToJSON instance. -}
@@ -223,12 +224,12 @@ newtype MCostingFun a = MCostingFun (Maybe (CostingFun a))
   deriving (Semigroup, Monoid) via (Alt Maybe (CostingFun a)) -- for mempty == MCostingFun Nothing
 
 -- Omit generating JSON for any costing functions that have not been set (are missing).
-deriving via
-  CustomJSON
-    '[OmitNothingFields, FieldLabelModifier (StripPrefix "param", LowerInitialCharacter)]
-    (BuiltinCostModelBase MCostingFun)
-  instance
-    ToJSON (BuiltinCostModelBase MCostingFun)
+instance ToJSON (BuiltinCostModelBase MCostingFun) where
+  toJSON = genericToJSON mBuiltinCostModelOptions
+  toEncoding = genericToEncoding mBuiltinCostModelOptions
+
+mBuiltinCostModelOptions :: Options
+mBuiltinCostModelOptions = builtinCostModelOptions {omitNothingFields = True}
 
 -- Needed to help derive various instances for BuiltinCostModelBase
 type AllArgumentModels (constraint :: Kind.Type -> Kind.Constraint) f =

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
@@ -59,8 +59,8 @@ import PlutusCore.Evaluation.Machine.ExMemoryUsage
 import Control.DeepSeq
 import Data.Default.Class
 import Data.Hashable
-import Deriving.Aeson
 import GHC.Exts
+import GHC.Generics (Generic)
 import Language.Haskell.TH.Syntax hiding
   ( Name
   , newName

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/JSON.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/JSON.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -O0 #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -12,30 +6,39 @@ a lot of time optimizing loads of Core whose performance doesn't matter. -}
 module PlutusCore.Evaluation.Machine.CostingFun.JSON () where
 
 import Data.Aeson
-import Deriving.Aeson
+import Data.List (stripPrefix)
+import Data.Maybe (fromMaybe)
 
 import PlutusCore.Evaluation.Machine.CostingFun.Core
 
-type ModelJSON prefix = CustomJSON '[FieldLabelModifier (StripPrefix prefix, CamelToSnake)]
+-- | Drop a prefix from a name, leaving the name unchanged if the prefix doesn't match.
+dropPrefix :: String -> String -> String
+dropPrefix prefix s = fromMaybe s (stripPrefix prefix s)
 
-type ModelArgumentJSON prefix =
-  CustomJSON
-    -- Without TagSingleConstructors the format can change unexpectedly if
-    -- you add/remove constructors because you don't get the tags if there's
-    -- only one constructor but you do if there's more than one.
-    '[ TagSingleConstructors
-     , SumTaggedObject "type" "arguments"
-     , ConstructorTagModifier (StripPrefix prefix, CamelToSnake)
-     ]
+{-| JSON options for the record types describing the shapes of costing functions: drop the
+type-name prefix from the field names and convert the rest to snake_case. -}
+modelOptions :: String -> Options
+modelOptions prefix =
+  defaultOptions {fieldLabelModifier = camelTo2 '_' . dropPrefix prefix}
 
-deriving via
-  ModelJSON "costingFun" (CostingFun model)
-  instance
-    FromJSON model => FromJSON (CostingFun model)
-deriving via
-  ModelJSON "costingFun" (CostingFun model)
-  instance
-    ToJSON model => ToJSON (CostingFun model)
+{-| JSON options for the sum types of costing function shapes.
+Without 'tagSingleConstructors' the format can change unexpectedly if
+you add/remove constructors because you don't get the tags if there's
+only one constructor but you do if there's more than one. -}
+modelArgumentOptions :: String -> Options
+modelArgumentOptions prefix =
+  defaultOptions
+    { constructorTagModifier = camelTo2 '_' . dropPrefix prefix
+    , sumEncoding = TaggedObject "type" "arguments"
+    , tagSingleConstructors = True
+    }
+
+instance FromJSON model => FromJSON (CostingFun model) where
+  parseJSON = genericParseJSON (modelOptions "costingFun")
+
+instance ToJSON model => ToJSON (CostingFun model) where
+  toJSON = genericToJSON (modelOptions "costingFun")
+  toEncoding = genericToEncoding (modelOptions "costingFun")
 
 deriving newtype instance FromJSON Intercept
 deriving newtype instance ToJSON Intercept
@@ -62,134 +65,115 @@ deriving newtype instance ToJSON Coefficient02
 deriving newtype instance FromJSON Coefficient12
 deriving newtype instance ToJSON Coefficient12
 
-deriving via
-  ModelArgumentJSON "ModelOneArgument" ModelOneArgument
-  instance
-    FromJSON ModelOneArgument
-deriving via
-  ModelArgumentJSON "ModelOneArgument" ModelOneArgument
-  instance
-    ToJSON ModelOneArgument
-deriving via
-  ModelArgumentJSON "ModelTwoArguments" ModelTwoArguments
-  instance
-    FromJSON ModelTwoArguments
-deriving via
-  ModelArgumentJSON "ModelTwoArguments" ModelTwoArguments
-  instance
-    ToJSON ModelTwoArguments
-deriving via
-  ModelArgumentJSON "ModelThreeArguments" ModelThreeArguments
-  instance
-    FromJSON ModelThreeArguments
-deriving via
-  ModelArgumentJSON "ModelThreeArguments" ModelThreeArguments
-  instance
-    ToJSON ModelThreeArguments
-deriving via
-  ModelArgumentJSON "ModelFourArguments" ModelFourArguments
-  instance
-    FromJSON ModelFourArguments
-deriving via
-  ModelArgumentJSON "ModelFourArguments" ModelFourArguments
-  instance
-    ToJSON ModelFourArguments
-deriving via
-  ModelArgumentJSON "ModelFiveArguments" ModelFiveArguments
-  instance
-    FromJSON ModelFiveArguments
-deriving via
-  ModelArgumentJSON "ModelFiveArguments" ModelFiveArguments
-  instance
-    ToJSON ModelFiveArguments
-deriving via
-  ModelArgumentJSON "ModelSixArguments" ModelSixArguments
-  instance
-    FromJSON ModelSixArguments
-deriving via
-  ModelArgumentJSON "ModelSixArguments" ModelSixArguments
-  instance
-    ToJSON ModelSixArguments
+instance FromJSON ModelOneArgument where
+  parseJSON = genericParseJSON (modelArgumentOptions "ModelOneArgument")
 
-deriving via
-  ModelJSON "modelSubtractedSizes" ModelSubtractedSizes
-  instance
-    FromJSON ModelSubtractedSizes
-deriving via
-  ModelJSON "modelSubtractedSizes" ModelSubtractedSizes
-  instance
-    ToJSON ModelSubtractedSizes
-deriving via
-  ModelJSON "oneVariableLinearFunction" OneVariableLinearFunction
-  instance
-    FromJSON OneVariableLinearFunction
-deriving via
-  ModelJSON "oneVariableLinearFunction" OneVariableLinearFunction
-  instance
-    ToJSON OneVariableLinearFunction
-deriving via
-  ModelJSON "twoVariableLinearFunction" TwoVariableLinearFunction
-  instance
-    FromJSON TwoVariableLinearFunction
-deriving via
-  ModelJSON "twoVariableLinearFunction" TwoVariableLinearFunction
-  instance
-    ToJSON TwoVariableLinearFunction
-deriving via
-  ModelJSON "oneVariableQuadraticFunction" OneVariableQuadraticFunction
-  instance
-    FromJSON OneVariableQuadraticFunction
-deriving via
-  ModelJSON "oneVariableQuadraticFunction" OneVariableQuadraticFunction
-  instance
-    ToJSON OneVariableQuadraticFunction
-deriving via
-  ModelJSON "twoVariableQuadraticFunction" TwoVariableQuadraticFunction
-  instance
-    FromJSON TwoVariableQuadraticFunction
-deriving via
-  ModelJSON "twoVariableQuadraticFunction" TwoVariableQuadraticFunction
-  instance
-    ToJSON TwoVariableQuadraticFunction
-deriving via
-  ModelJSON "expModCostingFunction" ExpModCostingFunction
-  instance
-    FromJSON ExpModCostingFunction
-deriving via
-  ModelJSON "expModCostingFunction" ExpModCostingFunction
-  instance
-    ToJSON ExpModCostingFunction
-deriving via
-  ModelJSON "modelConstantOrOneArgument" ModelConstantOrOneArgument
-  instance
-    FromJSON ModelConstantOrOneArgument
-deriving via
-  ModelJSON "modelConstantOrOneArgument" ModelConstantOrOneArgument
-  instance
-    ToJSON ModelConstantOrOneArgument
-deriving via
-  ModelJSON "modelConstantOrTwoArguments" ModelConstantOrTwoArguments
-  instance
-    FromJSON ModelConstantOrTwoArguments
-deriving via
-  ModelJSON "modelConstantOrTwoArguments" ModelConstantOrTwoArguments
-  instance
-    ToJSON ModelConstantOrTwoArguments
+instance ToJSON ModelOneArgument where
+  toJSON = genericToJSON (modelArgumentOptions "ModelOneArgument")
+  toEncoding = genericToEncoding (modelArgumentOptions "ModelOneArgument")
+
+instance FromJSON ModelTwoArguments where
+  parseJSON = genericParseJSON (modelArgumentOptions "ModelTwoArguments")
+
+instance ToJSON ModelTwoArguments where
+  toJSON = genericToJSON (modelArgumentOptions "ModelTwoArguments")
+  toEncoding = genericToEncoding (modelArgumentOptions "ModelTwoArguments")
+
+instance FromJSON ModelThreeArguments where
+  parseJSON = genericParseJSON (modelArgumentOptions "ModelThreeArguments")
+
+instance ToJSON ModelThreeArguments where
+  toJSON = genericToJSON (modelArgumentOptions "ModelThreeArguments")
+  toEncoding = genericToEncoding (modelArgumentOptions "ModelThreeArguments")
+
+instance FromJSON ModelFourArguments where
+  parseJSON = genericParseJSON (modelArgumentOptions "ModelFourArguments")
+
+instance ToJSON ModelFourArguments where
+  toJSON = genericToJSON (modelArgumentOptions "ModelFourArguments")
+  toEncoding = genericToEncoding (modelArgumentOptions "ModelFourArguments")
+
+instance FromJSON ModelFiveArguments where
+  parseJSON = genericParseJSON (modelArgumentOptions "ModelFiveArguments")
+
+instance ToJSON ModelFiveArguments where
+  toJSON = genericToJSON (modelArgumentOptions "ModelFiveArguments")
+  toEncoding = genericToEncoding (modelArgumentOptions "ModelFiveArguments")
+
+instance FromJSON ModelSixArguments where
+  parseJSON = genericParseJSON (modelArgumentOptions "ModelSixArguments")
+
+instance ToJSON ModelSixArguments where
+  toJSON = genericToJSON (modelArgumentOptions "ModelSixArguments")
+  toEncoding = genericToEncoding (modelArgumentOptions "ModelSixArguments")
+
+instance FromJSON ModelSubtractedSizes where
+  parseJSON = genericParseJSON (modelOptions "modelSubtractedSizes")
+
+instance ToJSON ModelSubtractedSizes where
+  toJSON = genericToJSON (modelOptions "modelSubtractedSizes")
+  toEncoding = genericToEncoding (modelOptions "modelSubtractedSizes")
+
+instance FromJSON OneVariableLinearFunction where
+  parseJSON = genericParseJSON (modelOptions "oneVariableLinearFunction")
+
+instance ToJSON OneVariableLinearFunction where
+  toJSON = genericToJSON (modelOptions "oneVariableLinearFunction")
+  toEncoding = genericToEncoding (modelOptions "oneVariableLinearFunction")
+
+instance FromJSON TwoVariableLinearFunction where
+  parseJSON = genericParseJSON (modelOptions "twoVariableLinearFunction")
+
+instance ToJSON TwoVariableLinearFunction where
+  toJSON = genericToJSON (modelOptions "twoVariableLinearFunction")
+  toEncoding = genericToEncoding (modelOptions "twoVariableLinearFunction")
+
+instance FromJSON OneVariableQuadraticFunction where
+  parseJSON = genericParseJSON (modelOptions "oneVariableQuadraticFunction")
+
+instance ToJSON OneVariableQuadraticFunction where
+  toJSON = genericToJSON (modelOptions "oneVariableQuadraticFunction")
+  toEncoding = genericToEncoding (modelOptions "oneVariableQuadraticFunction")
+
+instance FromJSON TwoVariableQuadraticFunction where
+  parseJSON = genericParseJSON (modelOptions "twoVariableQuadraticFunction")
+
+instance ToJSON TwoVariableQuadraticFunction where
+  toJSON = genericToJSON (modelOptions "twoVariableQuadraticFunction")
+  toEncoding = genericToEncoding (modelOptions "twoVariableQuadraticFunction")
+
+instance FromJSON ExpModCostingFunction where
+  parseJSON = genericParseJSON (modelOptions "expModCostingFunction")
+
+instance ToJSON ExpModCostingFunction where
+  toJSON = genericToJSON (modelOptions "expModCostingFunction")
+  toEncoding = genericToEncoding (modelOptions "expModCostingFunction")
+
+instance FromJSON ModelConstantOrOneArgument where
+  parseJSON = genericParseJSON (modelOptions "modelConstantOrOneArgument")
+
+instance ToJSON ModelConstantOrOneArgument where
+  toJSON = genericToJSON (modelOptions "modelConstantOrOneArgument")
+  toEncoding = genericToEncoding (modelOptions "modelConstantOrOneArgument")
+
+instance FromJSON ModelConstantOrTwoArguments where
+  parseJSON = genericParseJSON (modelOptions "modelConstantOrTwoArguments")
+
+instance ToJSON ModelConstantOrTwoArguments where
+  toJSON = genericToJSON (modelOptions "modelConstantOrTwoArguments")
+  toEncoding = genericToEncoding (modelOptions "modelConstantOrTwoArguments")
 
 -- See Note [Backward compatibility for costing functions] for ModelConstantOrLinear
-deriving via
-  ModelJSON "modelConstantOrLinear" ModelConstantOrLinear
-  instance
-    FromJSON ModelConstantOrLinear
-deriving via
-  ModelJSON "modelConstantOrLinear" ModelConstantOrLinear
-  instance
-    ToJSON ModelConstantOrLinear
-deriving via
-  ModelJSON "twoVariableWithInteractionFunction" TwoVariableWithInteractionFunction
-  instance
-    FromJSON TwoVariableWithInteractionFunction
-deriving via
-  ModelJSON "twoVariableWithInteractionFunction" TwoVariableWithInteractionFunction
-  instance
-    ToJSON TwoVariableWithInteractionFunction
+instance FromJSON ModelConstantOrLinear where
+  parseJSON = genericParseJSON (modelOptions "modelConstantOrLinear")
+
+instance ToJSON ModelConstantOrLinear where
+  toJSON = genericToJSON (modelOptions "modelConstantOrLinear")
+  toEncoding = genericToEncoding (modelOptions "modelConstantOrLinear")
+
+instance FromJSON TwoVariableWithInteractionFunction where
+  parseJSON = genericParseJSON (modelOptions "twoVariableWithInteractionFunction")
+
+instance ToJSON TwoVariableWithInteractionFunction where
+  toJSON = genericToJSON (modelOptions "twoVariableWithInteractionFunction")
+  toEncoding = genericToEncoding (modelOptions "twoVariableWithInteractionFunction")

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -1,5 +1,4 @@
 -- editorconfig-checker-disable-file
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -139,7 +138,6 @@ module PlutusCore.Evaluation.Machine.ExBudget
   , minusExBudget
   , ExBudgetBuiltin (..)
   , ExRestrictingBudget (..)
-  , LowerInitialCharacter
   , largeBudget
   , enormousBudget
   ) where
@@ -148,18 +146,20 @@ import PlutusCore.Evaluation.Machine.ExMemory
 import PlutusPrelude hiding (toList)
 
 import Codec.Serialise (Serialise (..))
+import Data.Aeson
+  ( FromJSON (..)
+  , Options
+  , ToJSON (..)
+  , defaultOptions
+  , fieldLabelModifier
+  , genericParseJSON
+  , genericToEncoding
+  , genericToJSON
+  )
 import Data.Semigroup
-import Deriving.Aeson
 import Language.Haskell.TH.Lift (Lift)
 import NoThunks.Class
 import Prettyprinter
-
-{-| This is used elsewhere to convert cost models into JSON objects where the
-names of the fields are exactly the same as the names of the builtins. -}
-data LowerInitialCharacter
-
-instance StringModifier LowerInitialCharacter where
-  getStringModifier = lowerInitialChar
 
 {-| A class for injecting a 'Builtin' into an @exBudgetCat@.
 We need it, because the constant application machinery calls 'spendBudget' before reducing a
@@ -175,9 +175,18 @@ instance ExBudgetBuiltin fun () where
 data ExBudget = ExBudget {exBudgetCPU :: ExCPU, exBudgetMemory :: ExMemory}
   deriving stock (Eq, Show, Generic, Lift)
   deriving anyclass (PrettyBy config, NFData, NoThunks, Serialise)
-  deriving (FromJSON, ToJSON) via CustomJSON '[FieldLabelModifier LowerInitialCharacter] ExBudget
 
--- LowerInitialCharacter won't actually do anything here, but let's have it in case we change the field names.
+-- 'lowerInitialChar' won't actually do anything here, but let's have it in case we change the
+-- field names.
+exBudgetOptions :: Options
+exBudgetOptions = defaultOptions {fieldLabelModifier = lowerInitialChar}
+
+instance ToJSON ExBudget where
+  toJSON = genericToJSON exBudgetOptions
+  toEncoding = genericToEncoding exBudgetOptions
+
+instance FromJSON ExBudget where
+  parseJSON = genericParseJSON exBudgetOptions
 
 -- | Subtract one 'ExBudget' from another. Does not guarantee that the result is positive.
 minusExBudget :: ExBudget -> ExBudget -> ExBudget

--- a/plutus-core/plutus-core/test/CostModelJSON/Spec.hs
+++ b/plutus-core/plutus-core/test/CostModelJSON/Spec.hs
@@ -1,0 +1,118 @@
+{-| Tests pinning the serialized JSON of the cost model types.
+
+The field names, constructor tags and structure of 'BuiltinCostModelBase' and
+'CekMachineCostsBase' are a frozen format: the serialized form has to match the checked-in
+@cost-model/data/*.json@ files, and the flattened keys become the ledger's cost model
+parameter names. Renaming any of them is an observable breakage rather than an implementation
+detail.
+
+Those data files are the frozen format, so they are used as the expected output directly and
+no second copy is needed. Comparing against them catches renamed fields, renamed constructor
+tags, and fields appearing or disappearing.
+
+Note that the models under test are themselves loaded from those files by Template Haskell, so
+this is a fixed-point check on the encoder rather than a check on the cost model numbers: a
+changed coefficient moves both sides together. Anything that breaks decoding already fails the
+build at that splice, which leaves the case where 'toJSON' alone drifts away from 'parseJSON' —
+possible because the two are written out separately.
+
+Everything is compared as 'Data.Aeson.Value's. Field order carries no meaning here: every
+consumer either parses the JSON or goes through 'CostModelParams', which is a sorted map. -}
+module CostModelJSON.Spec (test_costModelJSON) where
+
+import PlutusCore.DataFilePaths qualified as DFP
+import PlutusCore.Default (BuiltinSemanticsVariant (..), DefaultFun)
+import PlutusCore.Evaluation.Machine.BuiltinCostModel
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (cekCostModelForVariant)
+import PlutusCore.Evaluation.Machine.MachineParameters
+import UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
+
+import Barbies (bmap)
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Diff qualified as Diff
+import Data.Aeson.Encode.Pretty qualified as AesonPretty
+import Data.ByteString.Lazy.Char8 qualified as BSL8
+import Data.Functor.Identity (runIdentity)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+-- | Every semantics variant, with the data files holding its frozen cost model.
+variants :: [(String, BuiltinSemanticsVariant DefaultFun, FilePath, FilePath)]
+variants =
+  [ ("A", DefaultFunSemanticsVariantA, DFP.builtinCostModelFileA, DFP.cekMachineCostsFileA)
+  , ("B", DefaultFunSemanticsVariantB, DFP.builtinCostModelFileB, DFP.cekMachineCostsFileB)
+  , ("C", DefaultFunSemanticsVariantC, DFP.builtinCostModelFileC, DFP.cekMachineCostsFileC)
+  , ("D", DefaultFunSemanticsVariantD, DFP.builtinCostModelFileD, DFP.cekMachineCostsFileD)
+  , ("E", DefaultFunSemanticsVariantE, DFP.builtinCostModelFileE, DFP.cekMachineCostsFileE)
+  ]
+
+{-| Assert that @model@ serializes to exactly the JSON stored in @file@. On a mismatch the
+difference is reported as a JSON patch, which pinpoints the offending entries instead of
+printing both cost models in full. -}
+assertMatchesDataFile :: Aeson.ToJSON a => FilePath -> a -> Assertion
+assertMatchesDataFile file model = do
+  contents <- BSL8.readFile file
+  case Aeson.eitherDecode contents of
+    Left err -> assertFailure $ file ++ ": " ++ err
+    Right stored ->
+      assertEqualWithPatch ("serialized form no longer matches " ++ file) stored (Aeson.toJSON model)
+
+{-| Compare two JSON values, describing any difference as the JSON patch that turns the first
+into the second. -}
+assertEqualWithPatch :: String -> Aeson.Value -> Aeson.Value -> Assertion
+assertEqualWithPatch what expected actual
+  | expected == actual = pure ()
+  | otherwise =
+      assertFailure . unlines $
+        [ what
+        , "patch from the expected value to the actual one:"
+        , BSL8.unpack (AesonPretty.encodePretty (Diff.diff expected actual))
+        ]
+
+test_costModelJSON :: TestTree
+test_costModelJSON =
+  testGroup
+    "cost model JSON encoding stability"
+    [ testGroup
+        "toJSON matches the checked-in cost model data file"
+        [ testGroup
+            variantName
+            [ testCase "builtinCostModel" $
+                assertMatchesDataFile builtinFile (_builtinCostModel costModel)
+            , testCase "cekMachineCosts" $
+                assertMatchesDataFile cekFile (_machineCostModel costModel)
+            ]
+        | (variantName, variant, builtinFile, cekFile) <- variants
+        , let costModel = cekCostModelForVariant variant
+        ]
+    , testGroup
+        "field-omitting instances"
+        [ testCase "CekMachineCostsBase Maybe: all fields missing encodes to {}" $
+            assertEqualWithPatch
+              "unset machine costs were not omitted"
+              (Aeson.object [])
+              (Aeson.toJSON (bmap (const Nothing) cekMachineCostsA :: CekMachineCostsBase Maybe))
+        , testCase "BuiltinCostModelBase MCostingFun: all fields missing encodes to {}" $
+            assertEqualWithPatch
+              "unset costing functions were not omitted"
+              (Aeson.object [])
+              ( Aeson.toJSON
+                  ( bmap (const (MCostingFun Nothing)) builtinCostModelA
+                      :: BuiltinCostModelBase MCostingFun
+                  )
+              )
+        , testCase "CekMachineCostsBase Maybe: all fields present encodes as the base instance" $
+            assertEqualWithPatch
+              "fully populated machine costs differ from the base instance"
+              (Aeson.toJSON cekMachineCostsA)
+              (Aeson.toJSON (bmap (Just . runIdentity) cekMachineCostsA))
+        , testCase "BuiltinCostModelBase MCostingFun: all present encodes as the base instance" $
+            assertEqualWithPatch
+              "fully populated costing functions differ from the base instance"
+              (Aeson.toJSON builtinCostModelA)
+              (Aeson.toJSON (bmap (MCostingFun . Just) builtinCostModelA))
+        ]
+    ]
+  where
+    builtinCostModelA = _builtinCostModel (cekCostModelForVariant DefaultFunSemanticsVariantA)
+    cekMachineCostsA = _machineCostModel (cekCostModelForVariant DefaultFunSemanticsVariantA)

--- a/plutus-core/plutus-core/test/Spec.hs
+++ b/plutus-core/plutus-core/test/Spec.hs
@@ -13,6 +13,7 @@ import PlutusPrelude
 import CBOR.DataStability qualified
 import Check.Spec qualified as Check
 import CostModelInterface.Spec
+import CostModelJSON.Spec (test_costModelJSON)
 import CostModelSafety.Spec
 import Evaluation.Spec (test_evaluation)
 import Flat.Spec qualified as FlatSpec
@@ -262,6 +263,7 @@ allTests plcFiles rwFiles typeFiles typeErrorFiles =
     , test_evaluation
     , test_normalizationCheck
     , test_costModelInterface
+    , test_costModelJSON
     , test_costModelSafety
     , CBOR.DataStability.tests
     , Check.tests

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/CekMachineCosts.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/CekMachineCosts.hs
@@ -1,5 +1,4 @@
 -- editorconfig-checker-disable-file
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -15,12 +14,23 @@ module UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
 where
 
 import PlutusCore.Evaluation.Machine.ExBudget
+import PlutusPrelude (Generic, lowerInitialChar)
 
 import Barbies
 import Control.DeepSeq
+import Data.Aeson
+  ( FromJSON (..)
+  , Options
+  , ToJSON (..)
+  , defaultOptions
+  , fieldLabelModifier
+  , genericParseJSON
+  , genericToEncoding
+  , genericToJSON
+  , omitNothingFields
+  )
 import Data.Functor.Identity
 import Data.Text qualified as Text
-import Deriving.Aeson
 import Language.Haskell.TH.Syntax (Lift)
 import NoThunks.Class
 
@@ -52,27 +62,24 @@ data CekMachineCostsBase f
   deriving stock (Generic)
   deriving anyclass (FunctorB, TraversableB, ConstraintsB)
 
-deriving via
-  CustomJSON
-    '[FieldLabelModifier LowerInitialCharacter]
-    (CekMachineCostsBase Identity)
-  instance
-    ToJSON (CekMachineCostsBase Identity)
-deriving via
-  CustomJSON
-    '[FieldLabelModifier LowerInitialCharacter]
-    (CekMachineCostsBase Identity)
-  instance
-    FromJSON (CekMachineCostsBase Identity)
+cekMachineCostsOptions :: Options
+cekMachineCostsOptions = defaultOptions {fieldLabelModifier = lowerInitialChar}
+
+instance ToJSON (CekMachineCostsBase Identity) where
+  toJSON = genericToJSON cekMachineCostsOptions
+  toEncoding = genericToEncoding cekMachineCostsOptions
+
+instance FromJSON (CekMachineCostsBase Identity) where
+  parseJSON = genericParseJSON cekMachineCostsOptions
 
 -- This instance will omit the generation of JSON for Nothing fields,
 -- (any functors which have Maybe functor at the outer layer)
-deriving via
-  CustomJSON
-    '[OmitNothingFields, FieldLabelModifier LowerInitialCharacter]
-    (CekMachineCostsBase Maybe)
-  instance
-    ToJSON (CekMachineCostsBase Maybe)
+instance ToJSON (CekMachineCostsBase Maybe) where
+  toJSON = genericToJSON mCekMachineCostsOptions
+  toEncoding = genericToEncoding mCekMachineCostsOptions
+
+mCekMachineCostsOptions :: Options
+mCekMachineCostsOptions = cekMachineCostsOptions {omitNothingFields = True}
 
 deriving stock instance AllBF Show f CekMachineCostsBase => Show (CekMachineCostsBase f)
 deriving stock instance AllBF Eq f CekMachineCostsBase => Eq (CekMachineCostsBase f)


### PR DESCRIPTION
`plutus-core` used `deriving-aeson` only for the `CustomJSON` deriving-via instances of the cost model types. This PR rewrites those as plain `aeson` generic instances (`genericToJSON`/`genericToEncoding`/`genericParseJSON` with explicit `Options`) and drops both the dependency and the `allow-newer: deriving-aeson:aeson` exception that #7820 had to add because `deriving-aeson` caps `aeson < 2.3` on Hackage. The only public API change: `PlutusCore.Evaluation.Machine.ExBudget` no longer exports `LowerInitialCharacter`, which existed solely to support `deriving-aeson`.

The serialized JSON is unchanged, and the two commits are ordered so that this is checkable. The first adds tests comparing the serialized cost models against the checked-in `cost-model/data` files for every semantics variant, using those files as the expected output rather than a copy of them. The tests pass against the existing instances, and the second commit replaces the instances without touching them.

Closes #7870.
