### PR TITLE
Kwxm/uplc/deduce input type from file extension

### DIFF
--- a/doc/docusaurus/docs/uplc-cli-tool.md
+++ b/doc/docusaurus/docs/uplc-cli-tool.md
@@ -5,7 +5,7 @@ sidebar_position: 28
 # UPLC CLI Tool
 
 `uplc` is a command-line tool for working with Untyped Plutus Core (UPLC).
-It ships with every [Plutus release](https://github.com/IntersectMBO/plutus/releases) and is useful for developers who build, test, or ship plutus scripts.
+It ships with every [Plutus release](https://github.com/IntersectMBO/plutus/releases) and is useful for developers who build, test, or ship Plutus scripts.
 
 You can also build `uplc` from source by cloning the Plutus repository, running `nix develop`, and then running `cabal build uplc`.
 

--- a/doc/docusaurus/docs/uplc-cli-tool.md
+++ b/doc/docusaurus/docs/uplc-cli-tool.md
@@ -140,7 +140,7 @@ uplc evaluate --if hex -i script.hex
 uplc evaluate -i script.hex
 ```
 
-See [Input and output formats](#input-and-output-formats) below for the full list of extensions `uplc` recognises.
+See [Input and output formats](#input-and-output-formats) above for the full list of extensions `uplc` recognises.
 
 By default evaluation is silent about resource usage. To see how much CPU and memory a program consumes, pick a budget mode:
 
@@ -155,10 +155,10 @@ uplc evaluate -i program.uplc --tallying
 
 To capture `trace` output emitted by the program, use `--trace-mode`, e.g. `--trace-mode Logs`.
 
-## Applying arguments to a script
+## Applying a script to arguments
 
-A validator becomes a runnable program only once its arguments (datum, redeemer, script context, …) have been applied.
-`uplc apply` builds that application for you.
+A validator becomes a runnable program only once its arguments (datum, redeemer, script context, …) have been supplied.
+`uplc apply` builds the required application for you.
 Use `apply` when the arguments are themselves UPLC scripts, and `apply-to-flat-data` / `apply-to-cbor-data` when they are encoded `Data` values (the common case for on-chain arguments):
 
 ```bash
@@ -201,9 +201,10 @@ The report lists each pass that ran, in order, and shows the AST size before and
 When evaluation is enabled (see below), each row additionally shows the CPU and memory cost at that stage and the deltas against the previous stage.
 When `--certify --certifier-report` is used, the same per-pass numbers are also included in the certifier report file.
 
-## Input and output formats
+### Hex-encoded and blueprint inputs
 
-`uplc` has always supported textual and flat-encoded scripts, but two recent additions make it much easier to plug into existing toolchains:
+The `uplc` executable has always supported textual and flat-encoded scripts, but
+two recent additions make it much easier to plug into existing toolchains:
 
 __Hex-encoded scripts__.
 This is the format most off-chain tools, wallets, and block explorers use.

--- a/doc/docusaurus/docs/uplc-cli-tool.md
+++ b/doc/docusaurus/docs/uplc-cli-tool.md
@@ -5,7 +5,7 @@ sidebar_position: 28
 # UPLC CLI Tool
 
 `uplc` is a command-line tool for working with Untyped Plutus Core (UPLC).
-It ships with every [Plutus release](https://github.com/IntersectMBO/plutus/releases) and is useful for developers who build, test, or ship Plutus scripts.
+It ships with every [Plutus release](https://github.com/IntersectMBO/plutus/releases) and is useful for developers who build, test, or ship plutus scripts.
 
 You can also build `uplc` from source by cloning the Plutus repository, running `nix develop`, and then running `cabal build uplc`.
 
@@ -29,6 +29,52 @@ Both `uplc --help` and the `--help` of the most commonly used subcommands end wi
 | `example` | Show built-in example programs (`uplc example -a` lists them). |
 | `dump-cost-model` | Dump the cost model parameters. |
 | `print-builtin-signatures` | Print the signatures of the built-in functions. |
+
+#### Other tools
+
+There are two related (but less commonly used) tools called `pir` and `plc` for
+dealing with PIR (Plutus Intermediate Representation) and Typed Plutus Core
+respectively.  This document doesn't describe these tools in detail, but like
+`uplc` they have built-in help for both the main command and for subcommands,
+accessed via the `--help` option .
+
+### Input and output formats
+
+Most of the subcommands take an input file specified with the `-i` option (or can read from the
+standard input stream using `--stdin`). The input can be provided in a number of formats, specified
+using the `--if` or `--input-format` option.  Similarly, the `-o`/`--stdout` and `--of`/`--output-format`
+options can be used to specify an output stream and its format.
+
+The `uplc` executable understands the following file formats:
+
+- `textual` — human-readable UPLC syntax
+- `flat` / `flat-deBruijn` — flat-encoded with de Bruijn indices
+- `flat-named` — flat-encoded with textual names
+- `flat-namedDeBruijn` — flat-encoded with named de Bruijn indices
+- `serialised` — CBOR-wrapped flat with de Bruijn indices
+- `hex` — `serialised` plus textual hex encoding (what blueprints and most tools use)
+- `blueprint` — blueprint JSON
+
+#### Deducing formats from file extensions
+
+You often don't need to provide `--if`/`--of` explicitly: if `-i`/`-o` names a file with one of the extensions below, `uplc` deduces the format from the extension automatically.
+
+| Extension | Deduced format |
+| --- | --- |
+| `.uplc` | `textual` |
+| `.flat` | `flat` |
+| `.hex` | `hex` |
+| `.cbor` | `serialised` |
+
+An explicit `--if`/`--of` always takes precedence over the extension. Any other extension (including `.json`, used for blueprints) isn't recognised, so the tool falls back to `textual`, meaning blueprint input/output still needs `--if blueprint`/`--of blueprint` given explicitly. Reading from stdin or writing to stdout (when `-i`/`-o` is omitted) also defaults to `textual`.
+
+The same per-file deduction applies to `apply`, `apply-to-flat-data`, and `apply-to-cbor-data`: each input file's format is deduced independently from its own extension, unless `--if` is given, in which case it forces that one format for every file.
+
+
+Similarly the `plc` tool recognises its own textual extension, `.plc`, and also `.flat` (it doesn't support `serialised`, `hex`, or `blueprint`); `pir` recognises `.pir` for `textual` and `.flat` for `flat-named` (PIR doesn't have de Bruijn name variants, and doesn't support `serialised`, `hex`, or `blueprint` either).
+
+In all three tools a mismatched or unrecognised extension (e.g. a `.plc` file passed to `uplc`) is treated as `textual`; however `--if` and `--of` can always be used to specify a format explicitly.  
+
 
 ## Shell completion
 
@@ -70,6 +116,7 @@ uplc --fish-completion-script (command -v uplc) > ~/.config/fish/completions/upl
 ```
 
 The same flags work for the `plc` and `pir` tools; just substitute the program name.
+
 
 ## Evaluating scripts
 
@@ -154,7 +201,7 @@ The report lists each pass that ran, in order, and shows the AST size before and
 When evaluation is enabled (see below), each row additionally shows the CPU and memory cost at that stage and the deltas against the previous stage.
 When `--certify --certifier-report` is used, the same per-pass numbers are also included in the certifier report file.
 
-### Input and output formats
+## Input and output formats
 
 `uplc` has always supported textual and flat-encoded scripts, but two recent additions make it much easier to plug into existing toolchains:
 
@@ -173,31 +220,6 @@ You can feed a blueprint straight into `uplc` and get an optimized blueprint bac
 ```
 uplc optimize --if blueprint --of blueprint -i MyBlueprint.json -o MyBlueprint.opt.json
 ```
-
-#### Supported formats
-
-The full list of supported formats is:
-
-- `textual` — human-readable UPLC syntax
-- `flat` / `flat-deBruijn` — flat-encoded with de Bruijn indices
-- `flat-named` — flat-encoded with textual names
-- `flat-namedDeBruijn` — flat-encoded with named de Bruijn indices
-- `serialised` — CBOR-wrapped flat with de Bruijn indices
-- `hex` — `serialised` plus textual hex encoding (what blueprints and most tools use)
-- `blueprint` — blueprint JSON
-
-#### Deducing formats from file extensions
-
-You often don't need to pass `--if`/`--of` at all: if `-i`/`-o` names a file with one of the extensions below, `uplc` deduces the format from the extension automatically.
-
-| Extension | Deduced format |
-| --- | --- |
-| `.uplc` | `textual` |
-| `.flat` | `flat` (`flat-deBruijn`) |
-| `.hex` | `hex` |
-| `.cbor` | `serialised` |
-
-An explicit `--if`/`--of` always takes precedence over the extension. Any other extension (including `.json`, used for blueprints) isn't recognised and the tool falls back to `textual`, so blueprint input/output still needs `--if blueprint`/`--of blueprint` given explicitly. Reading from stdin or writing to stdout (when `-i`/`-o` is omitted) also defaults to `textual`.
 
 ### Configuring the optimization pipeline
 
@@ -289,3 +311,5 @@ uplc optimize --if blueprint --of blueprint -i MyBlueprint.json -o MyBlueprint-o
 
 Each validator is evaluated with the arguments under the corresponding subdirectory.
 The result is an optimized blueprint, and a per-validator report showing how the execution budget changed at each optimization step.
+
+

--- a/doc/docusaurus/docs/uplc-cli-tool.md
+++ b/doc/docusaurus/docs/uplc-cli-tool.md
@@ -87,6 +87,14 @@ Scripts as they appear on-chain (in blueprints, wallets, or block explorers) are
 uplc evaluate --if hex -i script.hex
 ```
 
+`uplc` can usually deduce the input format from the file's extension, so if the file is actually named with a `.hex` extension the `--if hex` above is optional:
+
+```bash
+uplc evaluate -i script.hex
+```
+
+See [Input and output formats](#input-and-output-formats) below for the full list of extensions `uplc` recognises.
+
 By default evaluation is silent about resource usage. To see how much CPU and memory a program consumes, pick a budget mode:
 
 - `--counting` (`-c`) — run to completion and report the total budget spent.
@@ -113,6 +121,15 @@ uplc apply --if flat Validator.flat Datum.flat Redeemer.flat Context.flat --of f
 # arguments are CBOR-encoded Data
 uplc apply-to-cbor-data --if flat Validator.flat Datum.cbor Redeemer.cbor Context.cbor --of flat -o Script.flat
 ```
+
+Since the file extensions here already indicate the formats, `--if` and `--of` aren't actually needed in these examples.
+For `apply` and its `apply-to-*-data` variants, each input file's format is deduced independently from its own extension, so formats can even be mixed:
+
+```bash
+uplc apply Validator.flat Datum.uplc Redeemer.flat Context.flat -o Script.flat
+```
+
+Passing `--if` explicitly overrides deduction and forces that one format for every input file instead.
 
 You can then evaluate the fully-applied script with `uplc evaluate`.
 
@@ -157,6 +174,8 @@ You can feed a blueprint straight into `uplc` and get an optimized blueprint bac
 uplc optimize --if blueprint --of blueprint -i MyBlueprint.json -o MyBlueprint.opt.json
 ```
 
+#### Supported formats
+
 The full list of supported formats is:
 
 - `textual` — human-readable UPLC syntax
@@ -164,8 +183,21 @@ The full list of supported formats is:
 - `flat-named` — flat-encoded with textual names
 - `flat-namedDeBruijn` — flat-encoded with named de Bruijn indices
 - `serialised` — CBOR-wrapped flat with de Bruijn indices
-- `hex` — `serialised` plus hex encoding (what blueprints and most tools use)
+- `hex` — `serialised` plus textual hex encoding (what blueprints and most tools use)
 - `blueprint` — blueprint JSON
+
+#### Deducing formats from file extensions
+
+You often don't need to pass `--if`/`--of` at all: if `-i`/`-o` names a file with one of the extensions below, `uplc` deduces the format from the extension automatically.
+
+| Extension | Deduced format |
+| --- | --- |
+| `.uplc` | `textual` |
+| `.flat` | `flat` (`flat-deBruijn`) |
+| `.hex` | `hex` |
+| `.cbor` | `serialised` |
+
+An explicit `--if`/`--of` always takes precedence over the extension. Any other extension (including `.json`, used for blueprints) isn't recognised and the tool falls back to `textual`, so blueprint input/output still needs `--if blueprint`/`--of blueprint` given explicitly. Reading from stdin or writing to stdout (when `-i`/`-o` is omitted) also defaults to `textual`.
 
 ### Configuring the optimization pipeline
 

--- a/plutus-executables/executables/pir/Main.hs
+++ b/plutus-executables/executables/pir/Main.hs
@@ -89,13 +89,24 @@ data Command
 ---------------- Option parsers ----------------
 
 pPirOptimiseOptions :: Parser PirOptimiseOptions
-pPirOptimiseOptions = PirOptimiseOptions <$> input <*> pPirInputFormat <*> output <*> pPirOutputFormat <*> printmode
+pPirOptimiseOptions =
+  (\(inp, ifmt) (outp, ofmt) mode -> PirOptimiseOptions inp ifmt outp ofmt mode)
+    <$> pPirInputWithFormat
+    <*> pPirOutputWithFormat
+    <*> printmode
 
 pPirConvertOptions :: Parser PirConvertOptions
-pPirConvertOptions = PirConvertOptions <$> input <*> pPirInputFormat <*> output <*> pPirOutputFormat <*> printmode
+pPirConvertOptions =
+  (\(inp, ifmt) (outp, ofmt) mode -> PirConvertOptions inp ifmt outp ofmt mode)
+    <$> pPirInputWithFormat
+    <*> pPirOutputWithFormat
+    <*> printmode
 
 pAnalyseOptions :: Parser AnalyseOptions
-pAnalyseOptions = AnalyseOptions <$> input <*> pPirInputFormat <*> output
+pAnalyseOptions =
+  (\(inp, ifmt) outp -> AnalyseOptions inp ifmt outp)
+    <$> pPirInputWithFormat
+    <*> output
 
 {-| Whether to perform optimisations or not.  The default here is True,
 ie *do* optimise; specifying --dont-optimise returns False. -}
@@ -118,12 +129,13 @@ pJustTest =
 
 pCompileOptions :: Parser CompileOptions
 pCompileOptions =
-  CompileOptions
+  ( \lang opt test (inp, ifmt) outp ofmt mode ->
+      CompileOptions lang opt test inp ifmt outp ofmt mode
+  )
     <$> pLanguage
     <*> pOptimise
     <*> pJustTest
-    <*> input
-    <*> pPirInputFormat
+    <*> pPirInputWithFormat
     <*> output
     <*> outputformat
     <*> printmode

--- a/plutus-executables/executables/plc/Main.hs
+++ b/plutus-executables/executables/plc/Main.hs
@@ -66,7 +66,11 @@ typecheckOpts :: Parser TypecheckOptions
 typecheckOpts = uncurry TypecheckOptions <$> plcInputWithFormat <*> output <*> printmode <*> nameformat
 
 eraseOpts :: Parser EraseOptions
-eraseOpts = uncurry EraseOptions <$> plcInputWithFormat <*> output <*> plcOutputFormat <*> printmode
+eraseOpts =
+  (\(inp, ifmt) (outp, ofmt) mode -> EraseOptions inp ifmt outp ofmt mode)
+    <$> plcInputWithFormat
+    <*> plcOutputWithFormat
+    <*> printmode
 
 evalOpts :: Parser EvalOptions
 evalOpts =
@@ -95,8 +99,8 @@ plutus langHelpText =
               "Evaluate a program on the CK machine"
               "plc evaluate -i program.plc"
           , Help.eg
-              "Erase types, producing an untyped Plutus Core program"
-              "plc erase --of textual -i program.plc -o program.uplc"
+              "Erase types, producing an untyped Plutus Core program (formats deduced from the .plc and .uplc extensions)"
+              "plc erase -i program.plc -o program.uplc"
           , Help.eg
               "Enable bash completion for the current shell"
               "source <(plc --bash-completion-script $(command -v plc))"
@@ -114,8 +118,9 @@ plutusOpts =
               "Given a list of input files f g1 g2 ... gn "
                 <> "containing Typed Plutus Core scripts, "
                 <> "output a script consisting of (... ((f g1) g2) ... gn); "
-                <> "for example, 'plc apply --if flat Validator.flat "
-                <> "Datum.flat Redeemer.flat Context.flat --of flat -o Script.flat'."
+                <> "for example, 'plc apply Validator.flat "
+                <> "Datum.flat Redeemer.flat Context.flat -o Script.flat' "
+                <> "(the formats are deduced from the .flat extensions)."
           )
       )
       <> command
@@ -127,9 +132,9 @@ plutusOpts =
                   <> "Typed Plutus Core script and d1,...,dn are files "
                   <> "containing flat-encoded data ojbects, output a script "
                   <> "consisting of f applied to the data objects; "
-                  <> "for example, 'plc apply-to-data --if "
-                  <> "flat Validator.flat Datum.flat Redeemer.flat Context.flat "
-                  <> "--of flat -o Script.flat'."
+                  <> "for example, 'plc apply-to-data "
+                  <> "Validator.flat Datum.flat Redeemer.flat Context.flat "
+                  <> "-o Script.flat' (the program format is deduced from the .flat extension)."
             )
         )
       <> command

--- a/plutus-executables/executables/plc/Main.hs
+++ b/plutus-executables/executables/plc/Main.hs
@@ -120,7 +120,8 @@ plutusOpts =
                 <> "output a script consisting of (... ((f g1) g2) ... gn); "
                 <> "for example, 'plc apply Validator.flat "
                 <> "Datum.flat Redeemer.flat Context.flat -o Script.flat' "
-                <> "(the formats are deduced from the .flat extensions)."
+                <> "(each file's format is deduced from its extension; "
+                <> "--if forces one format for all files)."
           )
       )
       <> command
@@ -205,8 +206,11 @@ plutusOpts =
 {-| Apply one script to a list of others and output the result.  All of the
 scripts must be PLC.Program objects. -}
 runApply :: ApplyOptions -> IO ()
-runApply (ApplyOptions inputfiles ifmt outp ofmt mode) = do
-  scripts <- mapM ((readProgram ifmt :: Input -> IO (PlcProg PLC.SrcSpan)) . FileInput) inputfiles
+runApply (ApplyOptions inputfiles outp ofmt mode) = do
+  scripts <-
+    mapM
+      (\(file, ifmt) -> readProgram ifmt (FileInput file) :: IO (PlcProg PLC.SrcSpan))
+      inputfiles
   let appliedScript =
         case map (\case p -> () <$ p) scripts of
           [] -> errorWithoutStackTrace "No input files"
@@ -217,12 +221,12 @@ runApply (ApplyOptions inputfiles ifmt outp ofmt mode) = do
 {-| Apply a PLC program to script to a list of flat-encoded Data objects and
 output the result. -}
 runApplyToData :: ApplyOptions -> IO ()
-runApplyToData (ApplyOptions inputfiles ifmt outp ofmt mode) = do
+runApplyToData (ApplyOptions inputfiles outp ofmt mode) = do
   case inputfiles of
     [] -> errorWithoutStackTrace "No input files"
-    p : ds -> do
+    (p, ifmt) : ds -> do
       prog@(PLC.Program _ version _) :: PlcProg PLC.SrcSpan <- readProgram ifmt (FileInput p)
-      args <- mapM (getDataObject version) ds
+      args <- mapM (getDataObject version . fst) ds
       let prog' = () <$ prog
           appliedScript = foldl1 (unsafeFromRight .* PLC.applyProgram) (prog' : args)
       writeProgram outp ofmt mode appliedScript

--- a/plutus-executables/executables/plc/Main.hs
+++ b/plutus-executables/executables/plc/Main.hs
@@ -63,16 +63,15 @@ data Command
 ---------------- Option parsers ----------------
 
 typecheckOpts :: Parser TypecheckOptions
-typecheckOpts = TypecheckOptions <$> input <*> inputformat <*> output <*> printmode <*> nameformat
+typecheckOpts = uncurry TypecheckOptions <$> plcInputWithFormat <*> output <*> printmode <*> nameformat
 
 eraseOpts :: Parser EraseOptions
-eraseOpts = EraseOptions <$> input <*> inputformat <*> output <*> outputformat <*> printmode
+eraseOpts = uncurry EraseOptions <$> plcInputWithFormat <*> output <*> plcOutputFormat <*> printmode
 
 evalOpts :: Parser EvalOptions
 evalOpts =
-  EvalOptions
-    <$> input
-    <*> inputformat
+  uncurry EvalOptions
+    <$> plcInputWithFormat
     <*> output
     <*> printmode
     <*> nameformat
@@ -110,7 +109,7 @@ plutusOpts =
     command
       "apply"
       ( info
-          (Apply <$> applyOpts)
+          (Apply <$> plcApplyOpts)
           ( progDesc $
               "Given a list of input files f g1 g2 ... gn "
                 <> "containing Typed Plutus Core scripts, "
@@ -122,7 +121,7 @@ plutusOpts =
       <> command
         "apply-to-data"
         ( info
-            (ApplyToData <$> applyOpts)
+            (ApplyToData <$> plcApplyOpts)
             ( progDesc $
                 "Given a list f d1 d2 ... dn where f is a "
                   <> "Typed Plutus Core script and d1,...,dn are files "
@@ -142,7 +141,7 @@ plutusOpts =
       <> command
         "convert"
         ( info
-            (Convert <$> convertOpts)
+            (Convert <$> plcConvertOpts)
             (progDesc "Convert a program between various formats")
         )
       <> command
@@ -194,7 +193,7 @@ plutusOpts =
             (progDesc "Print the signatures of the built-in functions.")
         )
   where
-    optimise desc = info (Optimise <$> optimiseOpts) $ progDesc desc
+    optimise desc = info (Optimise <$> plcOptimiseOpts) $ progDesc desc
 
 ---------------- Script application ----------------
 

--- a/plutus-executables/executables/uplc/Main.hs
+++ b/plutus-executables/executables/uplc/Main.hs
@@ -106,13 +106,13 @@ topLevelExamples =
       "Evaluate a textual UPLC program on the CEK machine"
       "uplc evaluate -i program.uplc"
   , Help.eg
-      "Evaluate a hex-encoded script and report the CPU/memory budget used"
-      "uplc evaluate --if hex -i script.hex --counting"
+      "Evaluate a hex-encoded script (format deduced from the .hex extension) and report the CPU/memory budget used"
+      "uplc evaluate -i script.hex --counting"
   , Help.eg
-      "Pretty-print a hex-encoded script as readable textual UPLC"
-      "uplc convert --if hex --of textual -i script.hex"
+      "Pretty-print a hex-encoded script as textual UPLC (input format deduced from .hex)"
+      "uplc convert -i script.hex --of textual"
   , Help.eg
-      "Optimise a script"
+      "Optimise a script (formats deduced from the .uplc extensions)"
       "uplc optimize -i program.uplc -o program-opt.uplc"
   , Help.eg
       "List the built-in example programs"
@@ -336,7 +336,10 @@ plutusOpts =
               )
               <> Help.examplesFooter
                 [ Help.eg
-                    "Apply a flat-encoded validator to its arguments"
+                    "Apply a flat-encoded validator to its arguments (formats deduced from the .flat extensions)"
+                    "uplc apply Validator.flat Datum.flat Redeemer.flat Context.flat -o Script.flat"
+                , Help.eg
+                    "The same, giving the formats explicitly with --if/--of instead of deducing them"
                     "uplc apply --if flat Validator.flat Datum.flat Redeemer.flat Context.flat --of flat -o Script.flat"
                 ]
           )
@@ -353,8 +356,8 @@ plutusOpts =
                 )
                 <> Help.examplesFooter
                   [ Help.eg
-                      "Apply a script to flat-encoded Data arguments"
-                      "uplc apply-to-flat-data --if flat Validator.flat Datum.flat Redeemer.flat Context.flat --of flat -o Script.flat"
+                      "Apply a script to flat-encoded Data arguments (program format deduced from the .flat extension)"
+                      "uplc apply-to-flat-data Validator.flat Datum.flat Redeemer.flat Context.flat -o Script.flat"
                   ]
             )
         )
@@ -370,8 +373,8 @@ plutusOpts =
                 )
                 <> Help.examplesFooter
                   [ Help.eg
-                      "Apply a script to CBOR-encoded Data arguments"
-                      "uplc apply-to-cbor-data --if flat Validator.flat Datum.cbor Redeemer.cbor Context.cbor --of flat -o Script.flat"
+                      "Apply a script to CBOR-encoded Data arguments (program format deduced from the .flat extension)"
+                      "uplc apply-to-cbor-data Validator.flat Datum.cbor Redeemer.cbor Context.cbor -o Script.flat"
                   ]
             )
         )
@@ -388,11 +391,14 @@ plutusOpts =
             ( progDesc "Convert a program between various formats."
                 <> Help.examplesFooter
                   [ Help.eg
-                      "Pretty-print a hex-encoded script as readable textual UPLC"
-                      "uplc convert --if hex --of textual -i script.hex"
+                      "Flat-encode a textual UPLC program (formats deduced from the .uplc and .flat extensions)"
+                      "uplc convert -i program.uplc -o program.flat"
                   , Help.eg
-                      "Flat-encode a textual UPLC program"
-                      "uplc convert --if textual --of flat -i program.uplc -o program.flat"
+                      "Convert a hex-encoded script to a textual file (both formats deduced from the extensions)"
+                      "uplc convert -i script.hex -o script.uplc"
+                  , Help.eg
+                      "Pretty-print a hex-encoded script to stdout; --if/--of override the deduced formats"
+                      "uplc convert --if hex --of textual -i script.hex"
                   ]
             )
         )
@@ -428,13 +434,16 @@ plutusOpts =
             ( progDesc "Evaluate an untyped Plutus Core program using the CEK machine."
                 <> Help.examplesFooter
                   [ Help.eg
-                      "Evaluate a textual UPLC program"
+                      "Evaluate a textual UPLC program (format deduced from the .uplc extension)"
                       "uplc evaluate -i program.uplc"
                   , Help.eg
-                      "Evaluate a hex-encoded script and report the budget used"
+                      "Evaluate a hex-encoded script (format deduced from .hex) and report the budget used"
+                      "uplc evaluate -i script.hex --counting"
+                  , Help.eg
+                      "The same, forcing the input format explicitly with --if instead of deducing it"
                       "uplc evaluate --if hex -i script.hex --counting"
                   , Help.eg
-                      "Evaluate a program piped in on stdin"
+                      "Evaluate a program piped in on stdin (defaults to textual)"
                       "echo '(program 1.1.0 (con integer 42))' | uplc evaluate"
                   ]
             )
@@ -478,10 +487,10 @@ plutusOpts =
         progDesc desc
           <> Help.examplesFooter
             [ Help.eg
-                "Optimise a textual UPLC script"
+                "Optimise a textual UPLC script (formats deduced from the .uplc extensions)"
                 "uplc optimize -i program.uplc -o program-opt.uplc"
             , Help.eg
-                "Optimise every validator in a CIP-57 blueprint"
+                "Optimise every validator in a CIP-57 blueprint (blueprint isn't deduced from .json, so give it explicitly)"
                 "uplc optimize --if blueprint --of blueprint -i bp.json -o bp-opt.json"
             ]
 

--- a/plutus-executables/executables/uplc/Main.hs
+++ b/plutus-executables/executables/uplc/Main.hs
@@ -196,9 +196,8 @@ cekmodel =
 
 benchmarkOpts :: Parser BenchmarkOptions
 benchmarkOpts =
-  BenchmarkOptions
-    <$> input
-    <*> inputformat
+  uncurry BenchmarkOptions
+    <$> inputWithFormat
     <*> builtinSemanticsVariant
     <*> option
       auto
@@ -212,9 +211,8 @@ benchmarkOpts =
 
 evalOpts :: Parser EvalOptions
 evalOpts =
-  EvalOptions
-    <$> input
-    <*> inputformat
+  uncurry EvalOptions
+    <$> inputWithFormat
     <*> printmode
     <*> nameformat
     <*> budgetmode
@@ -225,9 +223,8 @@ evalOpts =
 
 timeOpts :: Parser TimeEvalOptions
 timeOpts =
-  TimeEvalOptions
-    <$> input
-    <*> inputformat
+  uncurry TimeEvalOptions
+    <$> inputWithFormat
     <*> builtinSemanticsVariant
     <*> option
       auto
@@ -245,9 +242,8 @@ timeOpts =
 
 dbgOpts :: Parser DbgOptions
 dbgOpts =
-  DbgOptions
-    <$> input
-    <*> inputformat
+  uncurry DbgOptions
+    <$> inputWithFormat
     <*> cekmodel
     <*> builtinSemanticsVariant
 

--- a/plutus-executables/executables/uplc/Main.hs
+++ b/plutus-executables/executables/uplc/Main.hs
@@ -336,10 +336,13 @@ plutusOpts =
               )
               <> Help.examplesFooter
                 [ Help.eg
-                    "Apply a flat-encoded validator to its arguments (formats deduced from the .flat extensions)"
+                    "Apply a flat-encoded validator to its arguments (each file's format deduced from its extension)"
                     "uplc apply Validator.flat Datum.flat Redeemer.flat Context.flat -o Script.flat"
                 , Help.eg
-                    "The same, giving the formats explicitly with --if/--of instead of deducing them"
+                    "Input files may mix formats: a textual script applied to flat-encoded arguments"
+                    "uplc apply script.uplc arg1.flat arg2.flat -o Script.flat"
+                , Help.eg
+                    "Force one input format for every file with --if (overriding extension deduction)"
                     "uplc apply --if flat Validator.flat Datum.flat Redeemer.flat Context.flat --of flat -o Script.flat"
                 ]
           )
@@ -700,8 +703,11 @@ loadArgsIfEval opts
 {-| Apply one script to a list of others and output the result.  All of the
 scripts must be UPLC.Program objects. -}
 runApply :: ApplyOptions -> IO ()
-runApply (ApplyOptions inputfiles ifmt outp ofmt mode) = do
-  scripts <- mapM ((readProgram ifmt :: Input -> IO (UplcProg SrcSpan)) . FileInput) inputfiles
+runApply (ApplyOptions inputfiles outp ofmt mode) = do
+  scripts <-
+    mapM
+      (\(file, ifmt) -> readProgram ifmt (FileInput file) :: IO (UplcProg SrcSpan))
+      inputfiles
   let appliedScript =
         case void <$> scripts of
           [] -> errorWithoutStackTrace "No input files"
@@ -712,12 +718,12 @@ runApply (ApplyOptions inputfiles ifmt outp ofmt mode) = do
 {-| Apply a UPLC program to script to a list of flat-encoded Data objects and
 output the result. -}
 runApplyToFlatData :: ApplyOptions -> IO ()
-runApplyToFlatData (ApplyOptions inputfiles ifmt outp ofmt mode) =
+runApplyToFlatData (ApplyOptions inputfiles outp ofmt mode) =
   case inputfiles of
     [] -> errorWithoutStackTrace "No input files"
-    p : ds -> do
+    (p, ifmt) : ds -> do
       prog@(UPLC.Program _ version _) :: UplcProg SrcSpan <- readProgram ifmt (FileInput p)
-      args <- mapM (getDataObject version) ds
+      args <- mapM (getDataObject version . fst) ds
       let prog' = void prog
           appliedScript = foldl1 (unsafeFromRight .* UPLC.applyProgram) (prog' : args)
       writeProgram outp ofmt mode appliedScript
@@ -732,12 +738,12 @@ runApplyToFlatData (ApplyOptions inputfiles ifmt outp ofmt mode) =
 {-| Apply a UPLC program to script to a list of CBOR-encoded flat-encoded Data
 objects and output the result. -}
 runApplyToCborData :: ApplyOptions -> IO ()
-runApplyToCborData (ApplyOptions inputfiles ifmt outp ofmt mode) =
+runApplyToCborData (ApplyOptions inputfiles outp ofmt mode) =
   case inputfiles of
     [] -> errorWithoutStackTrace "No input files"
-    p : ds -> do
+    (p, ifmt) : ds -> do
       prog@(UPLC.Program _ version _) :: UplcProg SrcSpan <- readProgram ifmt (FileInput p)
-      args <- mapM (getCborDataObject version) ds
+      args <- mapM (getCborDataObject version . fst) ds
       let prog' = void prog
           appliedScript = foldl1 (unsafeFromRight .* UPLC.applyProgram) (prog' : args)
       writeProgram outp ofmt mode appliedScript

--- a/plutus-ledger-api/changelog.d/20260727_kenneth.mackenzie_deduce_format_from_extension.md
+++ b/plutus-ledger-api/changelog.d/20260727_kenneth.mackenzie_deduce_format_from_extension.md
@@ -6,6 +6,10 @@
   serialised. An explicit `--if`/`--of` always overrides the deduced format, and
   reading from stdin, writing to stdout, or an unrecognised extension still
   falls back to textual.
+- The `apply` command now deduces the format of each input file independently
+  from its own extension, so a script and arguments in different formats can be
+  applied together (for example a textual script applied to flat-encoded
+  arguments). An explicit `--if` still forces a single format for every file.
 
 ### Changed
 

--- a/plutus-ledger-api/changelog.d/20260727_kenneth.mackenzie_deduce_format_from_extension.md
+++ b/plutus-ledger-api/changelog.d/20260727_kenneth.mackenzie_deduce_format_from_extension.md
@@ -1,0 +1,23 @@
+### Added
+
+- The `uplc` and `plc` executables now deduce the input and output format from
+  the file extension when `--if`/`--of` is not supplied: `.uplc`/`.plc`/`.pir`
+  → textual, `.flat` → flat, and (for `uplc` only) `.hex` → hex and `.cbor` →
+  serialised. An explicit `--if`/`--of` always overrides the deduced format, and
+  reading from stdin, writing to stdout, or an unrecognised extension still
+  falls back to textual.
+
+### Changed
+
+- When an output file is given with `-o` but no `--of`, the output format is now
+  deduced from the file's extension instead of always defaulting to textual. A
+  command that relied on the old default (for example `uplc convert -i p.uplc -o
+  p.flat` with no `--of`) will now write the format implied by the extension;
+  pass `--of textual` explicitly to restore the previous behaviour.
+
+### Fixed
+
+- The `plc` executable no longer advertises the `serialised`, `hex` and
+  `blueprint` formats, which it never supported: `--if`/`--of` now accept only
+  `textual` and the `flat` variants, and unsupported values are rejected when
+  the command line is parsed rather than a failure occurring at runtime.

--- a/plutus-ledger-api/executables/src/PlutusCore/Executable/Parsers.hs
+++ b/plutus-ledger-api/executables/src/PlutusCore/Executable/Parsers.hs
@@ -183,19 +183,15 @@ inputWithFormat =
     <$> input
     <*> inputformatOptional
 
-{-| Like 'inputWithFormat' but for commands taking a list of input files; the
-format is deduced from the first file's extension when @--if@ is not given. -}
-filesWithFormat :: Parser (Files, Format)
-filesWithFormat =
-  (\fs mfmt -> (fs, resolveInputFormat (supportedFormats formatTable) mfmt (firstFileInput fs)))
+{-| Like 'inputWithFormat' but for commands taking a list of input files: each
+file is paired with the format to read it with. When @--if@ is given it forces
+that format for every file; otherwise each file's format is deduced
+independently from its own extension. -}
+filesWithFormats :: Parser [(FilePath, Format)]
+filesWithFormats =
+  (\fs mfmt -> [(f, resolveInputFormat (supportedFormats formatTable) mfmt (FileInput f)) | f <- fs])
     <$> files
     <*> inputformatOptional
-
-{-| The 'Input' to use for extension-based format deduction with a list of
-files: the first file, or stdin (giving the 'Textual' fallback) if empty. -}
-firstFileInput :: Files -> Input
-firstFileInput (f : _) = FileInput f
-firstFileInput [] = StdInput
 
 outputformat :: Parser Format
 outputformat =
@@ -250,8 +246,8 @@ files = some (argument str (metavar "[FILES...]" <> action "file"))
 
 applyOpts :: Parser ApplyOptions
 applyOpts =
-  (\(fs, ifmt) (outp, ofmt) mode -> ApplyOptions fs ifmt outp ofmt mode)
-    <$> filesWithFormat
+  (\fps (outp, ofmt) mode -> ApplyOptions fps outp ofmt mode)
+    <$> filesWithFormats
     <*> outputWithFormat
     <*> printmode
 
@@ -623,9 +619,9 @@ plcInputWithFormat =
     <$> input
     <*> plcInputFormatOptional
 
-plcFilesWithFormat :: Parser (Files, Format)
-plcFilesWithFormat =
-  (\fs mfmt -> (fs, resolveInputFormat (supportedFormats plcFormatTable) mfmt (firstFileInput fs)))
+plcFilesWithFormats :: Parser [(FilePath, Format)]
+plcFilesWithFormats =
+  (\fs mfmt -> [(f, resolveInputFormat (supportedFormats plcFormatTable) mfmt (FileInput f)) | f <- fs])
     <$> files
     <*> plcInputFormatOptional
 
@@ -637,8 +633,8 @@ plcOutputWithFormat =
 
 plcApplyOpts :: Parser ApplyOptions
 plcApplyOpts =
-  (\(fs, ifmt) (outp, ofmt) mode -> ApplyOptions fs ifmt outp ofmt mode)
-    <$> plcFilesWithFormat
+  (\fps (outp, ofmt) mode -> ApplyOptions fps outp ofmt mode)
+    <$> plcFilesWithFormats
     <*> plcOutputWithFormat
     <*> printmode
 

--- a/plutus-ledger-api/executables/src/PlutusCore/Executable/Parsers.hs
+++ b/plutus-ledger-api/executables/src/PlutusCore/Executable/Parsers.hs
@@ -149,6 +149,18 @@ resolveInputFormat supported Nothing (FileInput path) =
     _ -> Textual
 resolveInputFormat _ Nothing StdInput = Textual
 
+{-| The output-format counterpart of 'resolveInputFormat': an explicit @--of@
+always wins; otherwise the format is deduced from the output file's extension
+(restricted to @supported@), falling back to 'Textual' for stdout, the silent
+sink, an unrecognised extension, or an unsupported deduced format. -}
+resolveOutputFormat :: [Format] -> Maybe Format -> Output -> Format
+resolveOutputFormat _ (Just fmt) _ = fmt
+resolveOutputFormat supported Nothing (FileOutput path) =
+  case formatFromExtension path of
+    Just fmt | fmt `elem` supported -> fmt
+    _ -> Textual
+resolveOutputFormat _ Nothing _ = Textual
+
 {-| The @--if@/@--input-format@ option without a default, so we can tell whether
 the user supplied it and deduce the format from the file extension if not. -}
 inputformatOptional :: Parser (Maybe Format)
@@ -198,6 +210,29 @@ outputformat =
         <> help ("Output format: " ++ formatHelp)
     )
 
+{-| The @--of@/@--output-format@ option without a default, so we can tell
+whether the user supplied it and deduce the format from the @-o@ file extension
+if not. -}
+outputformatOptional :: Parser (Maybe Format)
+outputformatOptional =
+  optional $
+    option
+      (maybeReader formatReader)
+      ( long "of"
+          <> long "output-format"
+          <> metavar "FORMAT"
+          <> completeWith formatNames
+          <> help ("Output format (default: deduced from the file extension, or textual): " ++ formatHelp)
+      )
+
+{-| An output stream together with its format, deducing the format from the
+file extension when @--of@ is not given. See 'resolveOutputFormat'. -}
+outputWithFormat :: Parser (Output, Format)
+outputWithFormat =
+  (\outp mfmt -> (outp, resolveOutputFormat (supportedFormats formatTable) mfmt outp))
+    <$> output
+    <*> outputformatOptional
+
 tracemode :: Parser TraceMode
 tracemode =
   option
@@ -214,7 +249,11 @@ files :: Parser Files
 files = some (argument str (metavar "[FILES...]" <> action "file"))
 
 applyOpts :: Parser ApplyOptions
-applyOpts = uncurry ApplyOptions <$> filesWithFormat <*> output <*> outputformat <*> printmode
+applyOpts =
+  (\(fs, ifmt) (outp, ofmt) mode -> ApplyOptions fs ifmt outp ofmt mode)
+    <$> filesWithFormat
+    <*> outputWithFormat
+    <*> printmode
 
 printmode :: Parser PrintMode
 printmode =
@@ -258,7 +297,11 @@ printOpts :: Parser PrintOptions
 printOpts = PrintOptions <$> input <*> output <*> printmode
 
 convertOpts :: Parser ConvertOptions
-convertOpts = uncurry ConvertOptions <$> inputWithFormat <*> output <*> outputformat <*> printmode
+convertOpts =
+  (\(inp, ifmt) (outp, ofmt) mode -> ConvertOptions inp ifmt outp ofmt mode)
+    <$> inputWithFormat
+    <*> outputWithFormat
+    <*> printmode
 
 certifierOutputMode :: Parser CertifierOutputMode
 certifierOutputMode =
@@ -449,10 +492,11 @@ optimiseEvalOpts =
 
 optimiseOpts :: Parser (OptimiseOptions name a)
 optimiseOpts =
-  uncurry OptimiseOptions
+  ( \(inp, ifmt) (outp, ofmt) mode cert certOut sopts eopts ->
+      OptimiseOptions inp ifmt outp ofmt mode cert certOut sopts eopts
+  )
     <$> inputWithFormat
-    <*> output
-    <*> outputformat
+    <*> outputWithFormat
     <*> printmode
     <*> certifier
     <*> certifierOutputMode
@@ -559,18 +603,19 @@ plcInputFormatOptional =
           <> help ("Input format (default: deduced from the file extension, or textual): " ++ plcFormatHelp)
       )
 
-plcOutputFormat :: Parser Format
-plcOutputFormat =
-  option
-    (maybeReader plcFormatReader)
-    ( long "of"
-        <> long "output-format"
-        <> metavar "FORMAT"
-        <> value Textual
-        <> showDefault
-        <> completeWith plcFormatNames
-        <> help ("Output format: " ++ plcFormatHelp)
-    )
+{-| The @--of@ option for @plc@, without a default so the format can be deduced
+from the file extension when it isn't given. -}
+plcOutputFormatOptional :: Parser (Maybe Format)
+plcOutputFormatOptional =
+  optional $
+    option
+      (maybeReader plcFormatReader)
+      ( long "of"
+          <> long "output-format"
+          <> metavar "FORMAT"
+          <> completeWith plcFormatNames
+          <> help ("Output format (default: deduced from the file extension, or textual): " ++ plcFormatHelp)
+      )
 
 plcInputWithFormat :: Parser (Input, Format)
 plcInputWithFormat =
@@ -584,18 +629,33 @@ plcFilesWithFormat =
     <$> files
     <*> plcInputFormatOptional
 
+plcOutputWithFormat :: Parser (Output, Format)
+plcOutputWithFormat =
+  (\outp mfmt -> (outp, resolveOutputFormat (supportedFormats plcFormatTable) mfmt outp))
+    <$> output
+    <*> plcOutputFormatOptional
+
 plcApplyOpts :: Parser ApplyOptions
-plcApplyOpts = uncurry ApplyOptions <$> plcFilesWithFormat <*> output <*> plcOutputFormat <*> printmode
+plcApplyOpts =
+  (\(fs, ifmt) (outp, ofmt) mode -> ApplyOptions fs ifmt outp ofmt mode)
+    <$> plcFilesWithFormat
+    <*> plcOutputWithFormat
+    <*> printmode
 
 plcConvertOpts :: Parser ConvertOptions
-plcConvertOpts = uncurry ConvertOptions <$> plcInputWithFormat <*> output <*> plcOutputFormat <*> printmode
+plcConvertOpts =
+  (\(inp, ifmt) (outp, ofmt) mode -> ConvertOptions inp ifmt outp ofmt mode)
+    <$> plcInputWithFormat
+    <*> plcOutputWithFormat
+    <*> printmode
 
 plcOptimiseOpts :: Parser (OptimiseOptions name a)
 plcOptimiseOpts =
-  uncurry OptimiseOptions
+  ( \(inp, ifmt) (outp, ofmt) mode cert certOut sopts eopts ->
+      OptimiseOptions inp ifmt outp ofmt mode cert certOut sopts eopts
+  )
     <$> plcInputWithFormat
-    <*> output
-    <*> plcOutputFormat
+    <*> plcOutputWithFormat
     <*> printmode
     <*> certifier
     <*> certifierOutputMode

--- a/plutus-ledger-api/executables/src/PlutusCore/Executable/Parsers.hs
+++ b/plutus-ledger-api/executables/src/PlutusCore/Executable/Parsers.hs
@@ -14,6 +14,7 @@ import Control.Lens ((^.))
 import Data.List (intercalate)
 import Data.Maybe
 import Options.Applicative
+import System.FilePath (takeExtension)
 
 {-| Parser for an input stream. If none is specified,
 default to stdin for ease of use in pipeline. -}
@@ -95,7 +96,9 @@ formatTable =
 
 formatHelp :: String
 formatHelp =
-  intercalate ", " [maybe name (\d -> name <> " (" <> d <> ")") mdesc | (name, mdesc, _) <- formatTable]
+  intercalate
+    ", "
+    [maybe name (\d -> name <> " (" <> d <> ")") mdesc | (name, mdesc, _) <- formatTable]
 
 formatReader :: String -> Maybe Format
 formatReader s = listToMaybe [v | (name, _, v) <- formatTable, name == s]
@@ -115,6 +118,72 @@ inputformat =
         <> completeWith formatNames
         <> help ("Input format: " ++ formatHelp)
     )
+
+{-| Guess the input format from a file name's extension. Returns 'Nothing' for
+an unrecognised extension, in which case callers fall back to 'Textual'. -}
+formatFromExtension :: FilePath -> Maybe Format
+formatFromExtension path =
+  case takeExtension path of
+    ".uplc" -> Just Textual
+    ".plc" -> Just Textual
+    ".pir" -> Just Textual
+    ".flat" -> Just (Flat DeBruijn)
+    ".hex" -> Just Hex
+    ".cbor" -> Just Serialised
+    _ -> Nothing
+
+-- | The formats named in a format table.
+supportedFormats :: [(String, Maybe String, Format)] -> [Format]
+supportedFormats table = [v | (_, _, v) <- table]
+
+{-| Work out which input format to use. An explicit @--if@ always wins;
+otherwise the format is deduced from the input file's extension, restricted to
+@supported@, and falling back to 'Textual' for stdin, an unrecognised
+extension, or a deduced format the command doesn't support (eg @.hex@ for the
+@plc@ command, which only handles textual and Flat). -}
+resolveInputFormat :: [Format] -> Maybe Format -> Input -> Format
+resolveInputFormat _ (Just fmt) _ = fmt
+resolveInputFormat supported Nothing (FileInput path) =
+  case formatFromExtension path of
+    Just fmt | fmt `elem` supported -> fmt
+    _ -> Textual
+resolveInputFormat _ Nothing StdInput = Textual
+
+{-| The @--if@/@--input-format@ option without a default, so we can tell whether
+the user supplied it and deduce the format from the file extension if not. -}
+inputformatOptional :: Parser (Maybe Format)
+inputformatOptional =
+  optional $
+    option
+      (maybeReader formatReader)
+      ( long "if"
+          <> long "input-format"
+          <> metavar "FORMAT"
+          <> completeWith formatNames
+          <> help ("Input format (default: deduced from the file extension, or textual): " ++ formatHelp)
+      )
+
+{-| An input stream together with its format, deducing the format from the
+file extension when @--if@ is not given. See 'resolveInputFormat'. -}
+inputWithFormat :: Parser (Input, Format)
+inputWithFormat =
+  (\inp mfmt -> (inp, resolveInputFormat (supportedFormats formatTable) mfmt inp))
+    <$> input
+    <*> inputformatOptional
+
+{-| Like 'inputWithFormat' but for commands taking a list of input files; the
+format is deduced from the first file's extension when @--if@ is not given. -}
+filesWithFormat :: Parser (Files, Format)
+filesWithFormat =
+  (\fs mfmt -> (fs, resolveInputFormat (supportedFormats formatTable) mfmt (firstFileInput fs)))
+    <$> files
+    <*> inputformatOptional
+
+{-| The 'Input' to use for extension-based format deduction with a list of
+files: the first file, or stdin (giving the 'Textual' fallback) if empty. -}
+firstFileInput :: Files -> Input
+firstFileInput (f : _) = FileInput f
+firstFileInput [] = StdInput
 
 outputformat :: Parser Format
 outputformat =
@@ -145,7 +214,7 @@ files :: Parser Files
 files = some (argument str (metavar "[FILES...]" <> action "file"))
 
 applyOpts :: Parser ApplyOptions
-applyOpts = ApplyOptions <$> files <*> inputformat <*> output <*> outputformat <*> printmode
+applyOpts = uncurry ApplyOptions <$> filesWithFormat <*> output <*> outputformat <*> printmode
 
 printmode :: Parser PrintMode
 printmode =
@@ -189,7 +258,7 @@ printOpts :: Parser PrintOptions
 printOpts = PrintOptions <$> input <*> output <*> printmode
 
 convertOpts :: Parser ConvertOptions
-convertOpts = ConvertOptions <$> input <*> inputformat <*> output <*> outputformat <*> printmode
+convertOpts = uncurry ConvertOptions <$> inputWithFormat <*> output <*> outputformat <*> printmode
 
 certifierOutputMode :: Parser CertifierOutputMode
 certifierOutputMode =
@@ -380,9 +449,8 @@ optimiseEvalOpts =
 
 optimiseOpts :: Parser (OptimiseOptions name a)
 optimiseOpts =
-  OptimiseOptions
-    <$> input
-    <*> inputformat
+  uncurry OptimiseOptions
+    <$> inputWithFormat
     <*> output
     <*> outputformat
     <*> printmode
@@ -450,6 +518,90 @@ builtinSemanticsVariant =
           )
     )
 
+-- Specialised parsers for PLC (TPLC), which only supports textual and Flat
+-- formats. The @serialised@, @hex@ and @blueprint@ formats are not implemented
+-- for TPLC (the 'ProgramLike PlcProg' instance's
+-- 'loadASTfromSerialised'/'loadASTfromHex'/'serialiseAST' are unimplemented, and
+-- 'runErase'/'runOptimisations' reject them), so we must not offer them.
+
+plcFormatTable :: [(String, Maybe String, Format)]
+plcFormatTable =
+  [ ("textual", Nothing, Textual)
+  , ("flat-named", Just "names", Flat Named)
+  , ("flat", Just "de Bruijn indices", Flat DeBruijn)
+  , ("flat-deBruijn", Just "alias for flat", Flat DeBruijn)
+  , ("flat-namedDeBruijn", Just "names and de Bruijn indices", Flat NamedDeBruijn)
+  ]
+
+plcFormatHelp :: String
+plcFormatHelp =
+  intercalate
+    ", "
+    [maybe name (\d -> name <> " (" <> d <> ")") mdesc | (name, mdesc, _) <- plcFormatTable]
+
+plcFormatReader :: String -> Maybe Format
+plcFormatReader s = listToMaybe [v | (name, _, v) <- plcFormatTable, name == s]
+
+plcFormatNames :: [String]
+plcFormatNames = [name | (name, _, _) <- plcFormatTable]
+
+{-| The @--if@ option for @plc@, without a default so the format can be deduced
+from the file extension when it isn't given. -}
+plcInputFormatOptional :: Parser (Maybe Format)
+plcInputFormatOptional =
+  optional $
+    option
+      (maybeReader plcFormatReader)
+      ( long "if"
+          <> long "input-format"
+          <> metavar "FORMAT"
+          <> completeWith plcFormatNames
+          <> help ("Input format (default: deduced from the file extension, or textual): " ++ plcFormatHelp)
+      )
+
+plcOutputFormat :: Parser Format
+plcOutputFormat =
+  option
+    (maybeReader plcFormatReader)
+    ( long "of"
+        <> long "output-format"
+        <> metavar "FORMAT"
+        <> value Textual
+        <> showDefault
+        <> completeWith plcFormatNames
+        <> help ("Output format: " ++ plcFormatHelp)
+    )
+
+plcInputWithFormat :: Parser (Input, Format)
+plcInputWithFormat =
+  (\inp mfmt -> (inp, resolveInputFormat (supportedFormats plcFormatTable) mfmt inp))
+    <$> input
+    <*> plcInputFormatOptional
+
+plcFilesWithFormat :: Parser (Files, Format)
+plcFilesWithFormat =
+  (\fs mfmt -> (fs, resolveInputFormat (supportedFormats plcFormatTable) mfmt (firstFileInput fs)))
+    <$> files
+    <*> plcInputFormatOptional
+
+plcApplyOpts :: Parser ApplyOptions
+plcApplyOpts = uncurry ApplyOptions <$> plcFilesWithFormat <*> output <*> plcOutputFormat <*> printmode
+
+plcConvertOpts :: Parser ConvertOptions
+plcConvertOpts = uncurry ConvertOptions <$> plcInputWithFormat <*> output <*> plcOutputFormat <*> printmode
+
+plcOptimiseOpts :: Parser (OptimiseOptions name a)
+plcOptimiseOpts =
+  uncurry OptimiseOptions
+    <$> plcInputWithFormat
+    <*> output
+    <*> plcOutputFormat
+    <*> printmode
+    <*> certifier
+    <*> certifierOutputMode
+    <*> optimizeOpts
+    <*> optimiseEvalOpts
+
 -- Specialised parsers for PIR, which only supports ASTs over the Textual and
 -- Named types.
 
@@ -461,7 +613,9 @@ pirFormatTable =
 
 pirFormatHelp :: String
 pirFormatHelp =
-  intercalate " or " [maybe name (\d -> name <> " (" <> d <> ")") mdesc | (name, mdesc, _) <- pirFormatTable]
+  intercalate
+    " or "
+    [maybe name (\d -> name <> " (" <> d <> ")") mdesc | (name, mdesc, _) <- pirFormatTable]
 
 pirFormatReader :: String -> Maybe PirFormat
 pirFormatReader s = listToMaybe [v | (name, _, v) <- pirFormatTable, name == s]

--- a/plutus-ledger-api/executables/src/PlutusCore/Executable/Parsers.hs
+++ b/plutus-ledger-api/executables/src/PlutusCore/Executable/Parsers.hs
@@ -119,47 +119,97 @@ inputformat =
         <> help ("Input format: " ++ formatHelp)
     )
 
-{-| Guess the input format from a file name's extension. Returns 'Nothing' for
-an unrecognised extension, in which case callers fall back to 'Textual'. -}
-formatFromExtension :: FilePath -> Maybe Format
-formatFromExtension path =
-  case takeExtension path of
-    ".uplc" -> Just Textual
-    ".plc" -> Just Textual
-    ".pir" -> Just Textual
-    ".flat" -> Just (Flat DeBruijn)
-    ".hex" -> Just Hex
-    ".cbor" -> Just Serialised
-    _ -> Nothing
+-- File extensions that imply a non-textual format, common to every language
+-- (UPLC, PLC, PIR all share the same flat/hex/cbor conventions).
+nonTextualExtensionTable :: [(String, Format)]
+nonTextualExtensionTable =
+  [ (".flat", Flat DeBruijn)
+  , (".hex", Hex)
+  , (".cbor", Serialised)
+  ]
+
+{-| Guess the format from a file name's extension, given the extension that
+denotes /this/ language's own textual format (@.uplc@ for UPLC, @.plc@ for
+PLC). Returns 'Nothing' for an unrecognised extension, in which case callers
+fall back to 'Textual'. -}
+formatFromExtension :: String -> FilePath -> Maybe Format
+formatFromExtension textualExt path
+  | takeExtension path == textualExt = Just Textual
+  | otherwise = lookup (takeExtension path) nonTextualExtensionTable
+
+{-| Describe, for the @--if@/@--of@ help text, which extensions are deduced to
+which format for this language's @textualExt@, restricted to the formats in
+the given table (an extension whose format isn't in @table@ is omitted, since
+it falls back to textual instead). -}
+extensionHelp :: String -> [(String, Maybe String, Format)] -> String
+extensionHelp textualExt table =
+  intercalate ", " (mapMaybe describe ((textualExt, Textual) : nonTextualExtensionTable))
+  where
+    describe (ext, fmt) =
+      (\name -> ext <> " -> " <> name) <$> listToMaybe [name | (name, _, fmt') <- table, fmt == fmt']
+
+{-| The shared wording every language's @--if@/@--of@ "default:" help text is
+built from, wrapped around that language's own @ext -> format@ list. -}
+extensionDeductionSentence :: String -> String
+extensionDeductionSentence extList =
+  "deduced from the file extension ("
+    <> extList
+    <> "); any other extension, or reading from stdin/writing to stdout, defaults to textual"
+
+-- The explanation of the default embedded in the @--if@/@--of@ help text,
+-- shared between the input and output variants.
+extensionDeductionNote :: String -> [(String, Maybe String, Format)] -> String
+extensionDeductionNote textualExt table = extensionDeductionSentence (extensionHelp textualExt table)
+
+{-| Build the full @--if@/@--of@ help text for a format option: @kind@ (e.g.
+@"Input"@ or @"Output"@), the list of allowed values, and a note on how the
+default is chosen. Kept as two separate sentences, so the note (e.g. "deduced
+from the file extension") doesn't read as if it's parenthetically attached to
+the last format in the list (e.g. @blueprint@). -}
+formatOptionHelp :: String -> String -> String -> String
+formatOptionHelp kind formats note = kind ++ " format: " ++ formats ++ ". Default: " ++ note ++ "."
 
 -- | The formats named in a format table.
 supportedFormats :: [(String, Maybe String, Format)] -> [Format]
 supportedFormats table = [v | (_, _, v) <- table]
 
-{-| Work out which input format to use. An explicit @--if@ always wins;
-otherwise the format is deduced from the input file's extension, restricted to
-@supported@, and falling back to 'Textual' for stdin, an unrecognised
-extension, or a deduced format the command doesn't support (eg @.hex@ for the
-@plc@ command, which only handles textual and Flat). -}
-resolveInputFormat :: [Format] -> Maybe Format -> Input -> Format
-resolveInputFormat _ (Just fmt) _ = fmt
-resolveInputFormat supported Nothing (FileInput path) =
-  case formatFromExtension path of
-    Just fmt | fmt `elem` supported -> fmt
-    _ -> Textual
-resolveInputFormat _ Nothing StdInput = Textual
+{-| Generic extension-based format deduction, shared by every language's
+input-format resolver: an explicit @--if@ always wins; otherwise look up the
+input file's extension with @fromExt@, falling back to @deflt@ for stdin or an
+extension @fromExt@ doesn't recognise. -}
+deduceInputFormat :: (FilePath -> Maybe fmt) -> fmt -> Maybe fmt -> Input -> fmt
+deduceInputFormat _ _ (Just fmt) _ = fmt
+deduceInputFormat fromExt deflt Nothing (FileInput path) = fromMaybe deflt (fromExt path)
+deduceInputFormat _ deflt Nothing StdInput = deflt
 
-{-| The output-format counterpart of 'resolveInputFormat': an explicit @--of@
-always wins; otherwise the format is deduced from the output file's extension
-(restricted to @supported@), falling back to 'Textual' for stdout, the silent
-sink, an unrecognised extension, or an unsupported deduced format. -}
-resolveOutputFormat :: [Format] -> Maybe Format -> Output -> Format
-resolveOutputFormat _ (Just fmt) _ = fmt
-resolveOutputFormat supported Nothing (FileOutput path) =
-  case formatFromExtension path of
-    Just fmt | fmt `elem` supported -> fmt
-    _ -> Textual
-resolveOutputFormat _ Nothing _ = Textual
+{-| The output-format counterpart of 'deduceInputFormat': an explicit @--of@
+always wins; otherwise look up the output file's extension with @fromExt@,
+falling back to @deflt@ for stdout, the silent sink, or an unrecognised
+extension. -}
+deduceOutputFormat :: (FilePath -> Maybe fmt) -> fmt -> Maybe fmt -> Output -> fmt
+deduceOutputFormat _ _ (Just fmt) _ = fmt
+deduceOutputFormat fromExt deflt Nothing (FileOutput path) = fromMaybe deflt (fromExt path)
+deduceOutputFormat _ deflt Nothing _ = deflt
+
+{-| Work out which input format to use, deducing from the input file's
+extension (using @textualExt@ as this language's own textual extension)
+restricted to @supported@ (eg @.hex@ isn't deduced for the @plc@ command,
+which only handles textual and Flat). -}
+resolveInputFormat :: String -> [Format] -> Maybe Format -> Input -> Format
+resolveInputFormat textualExt supported =
+  deduceInputFormat (supportedFormatFromExtension textualExt supported) Textual
+
+-- | The output-format counterpart of 'resolveInputFormat'.
+resolveOutputFormat :: String -> [Format] -> Maybe Format -> Output -> Format
+resolveOutputFormat textualExt supported =
+  deduceOutputFormat (supportedFormatFromExtension textualExt supported) Textual
+
+-- | 'formatFromExtension', restricted to the formats in @supported@.
+supportedFormatFromExtension :: String -> [Format] -> FilePath -> Maybe Format
+supportedFormatFromExtension textualExt supported path =
+  case formatFromExtension textualExt path of
+    Just fmt | fmt `elem` supported -> Just fmt
+    _ -> Nothing
 
 {-| The @--if@/@--input-format@ option without a default, so we can tell whether
 the user supplied it and deduce the format from the file extension if not. -}
@@ -172,14 +222,14 @@ inputformatOptional =
           <> long "input-format"
           <> metavar "FORMAT"
           <> completeWith formatNames
-          <> help ("Input format (default: deduced from the file extension, or textual): " ++ formatHelp)
+          <> help (formatOptionHelp "Input" formatHelp (extensionDeductionNote ".uplc" formatTable))
       )
 
 {-| An input stream together with its format, deducing the format from the
 file extension when @--if@ is not given. See 'resolveInputFormat'. -}
 inputWithFormat :: Parser (Input, Format)
 inputWithFormat =
-  (\inp mfmt -> (inp, resolveInputFormat (supportedFormats formatTable) mfmt inp))
+  (\inp mfmt -> (inp, resolveInputFormat ".uplc" (supportedFormats formatTable) mfmt inp))
     <$> input
     <*> inputformatOptional
 
@@ -189,7 +239,8 @@ that format for every file; otherwise each file's format is deduced
 independently from its own extension. -}
 filesWithFormats :: Parser [(FilePath, Format)]
 filesWithFormats =
-  (\fs mfmt -> [(f, resolveInputFormat (supportedFormats formatTable) mfmt (FileInput f)) | f <- fs])
+  ( \fs mfmt -> [(f, resolveInputFormat ".uplc" (supportedFormats formatTable) mfmt (FileInput f)) | f <- fs]
+  )
     <$> files
     <*> inputformatOptional
 
@@ -218,14 +269,14 @@ outputformatOptional =
           <> long "output-format"
           <> metavar "FORMAT"
           <> completeWith formatNames
-          <> help ("Output format (default: deduced from the file extension, or textual): " ++ formatHelp)
+          <> help (formatOptionHelp "Output" formatHelp (extensionDeductionNote ".uplc" formatTable))
       )
 
 {-| An output stream together with its format, deducing the format from the
 file extension when @--of@ is not given. See 'resolveOutputFormat'. -}
 outputWithFormat :: Parser (Output, Format)
 outputWithFormat =
-  (\outp mfmt -> (outp, resolveOutputFormat (supportedFormats formatTable) mfmt outp))
+  (\outp mfmt -> (outp, resolveOutputFormat ".uplc" (supportedFormats formatTable) mfmt outp))
     <$> output
     <*> outputformatOptional
 
@@ -242,7 +293,15 @@ tracemode =
     )
 
 files :: Parser Files
-files = some (argument str (metavar "[FILES...]" <> action "file"))
+files =
+  some
+    ( argument
+        str
+        ( metavar "[FILES...]"
+            <> action "file"
+            <> help "Input files; each file's format is deduced from its own extension unless --if is given"
+        )
+    )
 
 applyOpts :: Parser ApplyOptions
 applyOpts =
@@ -596,7 +655,7 @@ plcInputFormatOptional =
           <> long "input-format"
           <> metavar "FORMAT"
           <> completeWith plcFormatNames
-          <> help ("Input format (default: deduced from the file extension, or textual): " ++ plcFormatHelp)
+          <> help (formatOptionHelp "Input" plcFormatHelp (extensionDeductionNote ".plc" plcFormatTable))
       )
 
 {-| The @--of@ option for @plc@, without a default so the format can be deduced
@@ -610,24 +669,25 @@ plcOutputFormatOptional =
           <> long "output-format"
           <> metavar "FORMAT"
           <> completeWith plcFormatNames
-          <> help ("Output format (default: deduced from the file extension, or textual): " ++ plcFormatHelp)
+          <> help (formatOptionHelp "Output" plcFormatHelp (extensionDeductionNote ".plc" plcFormatTable))
       )
 
 plcInputWithFormat :: Parser (Input, Format)
 plcInputWithFormat =
-  (\inp mfmt -> (inp, resolveInputFormat (supportedFormats plcFormatTable) mfmt inp))
+  (\inp mfmt -> (inp, resolveInputFormat ".plc" (supportedFormats plcFormatTable) mfmt inp))
     <$> input
     <*> plcInputFormatOptional
 
 plcFilesWithFormats :: Parser [(FilePath, Format)]
 plcFilesWithFormats =
-  (\fs mfmt -> [(f, resolveInputFormat (supportedFormats plcFormatTable) mfmt (FileInput f)) | f <- fs])
+  ( \fs mfmt -> [(f, resolveInputFormat ".plc" (supportedFormats plcFormatTable) mfmt (FileInput f)) | f <- fs]
+  )
     <$> files
     <*> plcInputFormatOptional
 
 plcOutputWithFormat :: Parser (Output, Format)
 plcOutputWithFormat =
-  (\outp mfmt -> (outp, resolveOutputFormat (supportedFormats plcFormatTable) mfmt outp))
+  (\outp mfmt -> (outp, resolveOutputFormat ".plc" (supportedFormats plcFormatTable) mfmt outp))
     <$> output
     <*> plcOutputFormatOptional
 
@@ -679,31 +739,80 @@ pirFormatReader s = listToMaybe [v | (name, _, v) <- pirFormatTable, name == s]
 pirFormatNames :: [String]
 pirFormatNames = [name | (name, _, _) <- pirFormatTable]
 
-pPirInputFormat :: Parser PirFormat
-pPirInputFormat =
-  option
-    (maybeReader pirFormatReader)
-    ( long "if"
-        <> long "input-format"
-        <> metavar "PIR-FORMAT"
-        <> value TextualPir
-        <> showDefault
-        <> completeWith pirFormatNames
-        <> help ("Input format: " ++ pirFormatHelp)
-    )
+-- File extensions recognised for PIR: its own textual extension, plus flat
+-- encoding (PIR doesn't support de Bruijn names, so unlike UPLC/PLC there's
+-- only one flat variant to recognise).
+pirExtensionTable :: [(String, PirFormat)]
+pirExtensionTable =
+  [ (".pir", TextualPir)
+  , (".flat", FlatNamed)
+  ]
 
-pPirOutputFormat :: Parser PirFormat
-pPirOutputFormat =
-  option
-    (maybeReader pirFormatReader)
-    ( long "of"
-        <> long "output-format"
-        <> metavar "PIR-FORMAT"
-        <> value TextualPir
-        <> showDefault
-        <> completeWith pirFormatNames
-        <> help ("Output format: " ++ pirFormatHelp)
-    )
+{-| Guess the PIR format from a file name's extension. Returns 'Nothing' for
+an unrecognised extension, in which case callers fall back to 'TextualPir'. -}
+pirFormatFromExtension :: FilePath -> Maybe PirFormat
+pirFormatFromExtension path = lookup (takeExtension path) pirExtensionTable
+
+-- The parenthetical explanation embedded in the PIR @--if@/@--of@ "default:"
+-- help text, shared between the input and output variants.
+pirExtensionDeductionNote :: String
+pirExtensionDeductionNote =
+  extensionDeductionSentence
+    (intercalate ", " [ext <> " -> " <> show fmt | (ext, fmt) <- pirExtensionTable])
+
+{-| Work out which PIR format to use. An explicit @--if@/@--of@ always wins;
+otherwise the format is deduced from the file's extension, falling back to
+'TextualPir' for stdin/stdout or an unrecognised extension. -}
+resolvePirInputFormat :: Maybe PirFormat -> Input -> PirFormat
+resolvePirInputFormat = deduceInputFormat pirFormatFromExtension TextualPir
+
+-- | The output-format counterpart of 'resolvePirInputFormat'.
+resolvePirOutputFormat :: Maybe PirFormat -> Output -> PirFormat
+resolvePirOutputFormat = deduceOutputFormat pirFormatFromExtension TextualPir
+
+{-| The @--if@ option for @pir@, without a default so the format can be deduced
+from the file extension when it isn't given. -}
+pPirInputFormatOptional :: Parser (Maybe PirFormat)
+pPirInputFormatOptional =
+  optional $
+    option
+      (maybeReader pirFormatReader)
+      ( long "if"
+          <> long "input-format"
+          <> metavar "PIR-FORMAT"
+          <> completeWith pirFormatNames
+          <> help (formatOptionHelp "Input" pirFormatHelp pirExtensionDeductionNote)
+      )
+
+{-| The @--of@ option for @pir@, without a default so the format can be deduced
+from the file extension when it isn't given. -}
+pPirOutputFormatOptional :: Parser (Maybe PirFormat)
+pPirOutputFormatOptional =
+  optional $
+    option
+      (maybeReader pirFormatReader)
+      ( long "of"
+          <> long "output-format"
+          <> metavar "PIR-FORMAT"
+          <> completeWith pirFormatNames
+          <> help (formatOptionHelp "Output" pirFormatHelp pirExtensionDeductionNote)
+      )
+
+{-| An input stream together with its PIR format, deducing the format from the
+file extension when @--if@ is not given. See 'resolvePirInputFormat'. -}
+pPirInputWithFormat :: Parser (Input, PirFormat)
+pPirInputWithFormat =
+  (\inp mfmt -> (inp, resolvePirInputFormat mfmt inp))
+    <$> input
+    <*> pPirInputFormatOptional
+
+{-| An output stream together with its PIR format, deducing the format from
+the file extension when @--of@ is not given. See 'resolvePirOutputFormat'. -}
+pPirOutputWithFormat :: Parser (Output, PirFormat)
+pPirOutputWithFormat =
+  (\outp mfmt -> (outp, resolvePirOutputFormat mfmt outp))
+    <$> output
+    <*> pPirOutputFormatOptional
 
 -- Which language: PLC or UPLC?
 

--- a/plutus-ledger-api/executables/src/PlutusCore/Executable/Types.hs
+++ b/plutus-ledger-api/executables/src/PlutusCore/Executable/Types.hs
@@ -106,7 +106,10 @@ data OptimiseOptions name a
       OptimiseEvalOpts
 data PrintOptions = PrintOptions Input Output PrintMode
 newtype ExampleOptions = ExampleOptions ExampleMode
-data ApplyOptions = ApplyOptions Files Format Output Format PrintMode
+
+{-| Each input file is paired with the input format to read it with (the
+explicit @--if@, or the format deduced from that file's own extension). -}
+data ApplyOptions = ApplyOptions [(FilePath, Format)] Output Format PrintMode
 
 data EvalArgKind
   = -- | Each argument is a program


### PR DESCRIPTION
I've typed
```
cabal run uplc -- -i file.flat --if flat
```
hundreds of times and finally got fed up having to explicitly specify the input format.  This PR extends `uplc` to infer input and output formats from the file extension for `.uplc`, `.flat`, `.hex`, and `.cbor` files, although `--if` and `--of` can still be used to override this, and must be used for formats like `blueprint` and `flat-named` that we don't have standard extensions for.  The `plc` and `pir` commands have been similarly extended.  Most of the code was generated by Claude, although it needed quite a lot of guidance.